### PR TITLE
Feature/contrast picker redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,14 +245,26 @@ the live page reflects the merged commit before calling anything fixed.
 ## Domain glossary
 
 - **Scale** — one base color and the 10 shades derived from it. The app supports
-  multiple scales at once; each has a numeric `id`. In exported code they're
-  named `color1`, `color2`, … by their **1-based position** (`scaleIndex + 1`),
-  *not* by `id`.
+  multiple scales at once; each has a numeric `id`, a base `color`, and a
+  `name`. The `name` is **auto-derived from the hue** (`colorUtils.nameFromHex`,
+  e.g. blue) until the user edits it, after which it's left alone (tracked by
+  `nameEdited` in `App`'s local state, *not* on the shared `ColorScale` type).
+- **Slug** — the export-safe form of a scale's `name`
+  (`colorUtils.slugify`), de-duped across scales by `colorUtils.uniqueSlugs`
+  (collisions get `-2`, `-3`…). Exported variables are `--<slug>-<shade>`
+  (CSS / Tailwind 4) or `<slug>: { … }` (Tailwind 3). Both
+  [CodeBlock](./src/components/CodeBlock.tsx) and
+  [ContrastChecker](./src/components/ContrastChecker.tsx) labels go through
+  `uniqueSlugs` so naming stays consistent. (This replaced the old positional
+  `color1`/`color2` naming.)
 - **Shade** — one step on a scale, keyed by `shadeNumbers` `50 100 200 300 400
   500 600 700 800 900`. **500 is the unmodified base color.** Below 500 mixes
   toward white, above 500 toward black.
-- **Combination** — an ordered pair of shades shown in the contrast table:
-  `color1` is foreground, `color2` is background.
+- **Contrast picker** — [ContrastChecker](./src/components/ContrastChecker.tsx)
+  is a *pick-a-background → legible-foregrounds* flow (not a full pairings
+  table). Results are the shades scoring ≥3:1 against the chosen background,
+  grouped by tier. Contrast is symmetric, so foreground/background only matters
+  for the preview, not the ratio.
 - **Contrast levels** — `AAA` (≥7:1), `AA` (≥4.5:1), `AA Large` (≥3.1:1). The
   table only lists pairs ≥3:1; anything lower is dropped, not shown as "Fail".
 - **Theme format vs. color format** — *theme format* is the output syntax

--- a/PLAN.md
+++ b/PLAN.md
@@ -43,8 +43,29 @@ generated demo and is not part of the suite.
 - [ ] Remove or ignore the `tests-examples/` demo so it isn't mistaken for real tests.
 - [ ] `npx playwright test` passes.
 
+### 3. Generate a palette from an image
+
+**Status:** not started · **Type:** `feature`
+
+Let designers seed scales from an uploaded image instead of picking hex by hand.
+Decided approach: **extract the top N dominant colors**, each becoming one base
+color (a `500`), auto-named via `colorUtils.nameFromHex`.
+
+- [ ] Image upload / drag-and-drop control in the color selection section.
+- [ ] Sample pixels onto a `<canvas>` and quantize to N dominant colors
+      (hand-rolled — e.g. median-cut or coarse bucketing — no new dependency
+      unless justified first; keep it in `colorUtils`).
+- [ ] A control for how many colors to extract (N).
+- [ ] Each extracted color becomes a new scale (base + auto-name); de-dupe
+      against existing scales.
+- [ ] Process the image client-side only — never upload it anywhere.
+- [ ] Tests: extraction returns N valid hex colors; scales are created and named.
+
 ---
 
 ## Done
 
-_(none yet)_
+- **Color selection: naming + designer optimizations** (branch
+  `feature/contrast-picker-redesign`). Editable, hue-auto-named scales; names
+  flow into the export (slugified + de-duped) and contrast labels; varied
+  default color per new scale; click-to-copy swatch hex; reset-palette control.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -97,7 +97,7 @@ const App = () => {
 					>
 						<div className='flex sm:flex-col gap-xs'>
 							<ColorInput
-								initialColor={scale.color}
+								color={scale.color}
 								name={scale.name}
 								autoName={colorUtils.nameFromHex(scale.color)}
 								onColorChange={(newColor) =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,19 +1,35 @@
 import { useState, useCallback } from 'react'
+import { colorUtils, type ColorScale } from '../utils/colorUtils'
 import ColorInput from './ColorInput'
-import ColorScale from './ColorScale'
+import ColorScale2 from './ColorScale'
 import CodeBlock from './CodeBlock'
 import ContrastChecker from './ContrastChecker'
 
+interface ScaleState extends ColorScale {
+	// True once the user types a name, which stops auto-naming from the hue.
+	nameEdited: boolean
+}
+
+const makeScale = (id: number, index: number): ScaleState => {
+	const color = colorUtils.defaultColorForIndex(index)
+	return {
+		id,
+		color,
+		name: colorUtils.nameFromHex(color),
+		nameEdited: false,
+	}
+}
+
 const App = () => {
-	const [colorScales, setColorScales] = useState([
-		{ id: 1, color: '#3b82f6' },
+	const [colorScales, setColorScales] = useState<ScaleState[]>([
+		makeScale(1, 0),
 	])
 	const [nextId, setNextId] = useState(2)
 
 	const addColorScale = useCallback(() => {
 		setColorScales((prevScales) => [
 			...prevScales,
-			{ id: nextId, color: '#3b82f6' },
+			makeScale(nextId, prevScales.length),
 		])
 		setNextId((prev) => prev + 1)
 	}, [nextId])
@@ -26,15 +42,53 @@ const App = () => {
 
 	const handleColorChange = useCallback((id: number, newColor: string) => {
 		setColorScales((prevScales) =>
-			prevScales.map((s) => (s.id === id ? { ...s, color: newColor } : s))
+			prevScales.map((s) =>
+				s.id === id
+					? {
+							...s,
+							color: newColor,
+							// Keep the name in sync with the hue until the
+							// user takes ownership of it.
+							name: s.nameEdited
+								? s.name
+								: colorUtils.nameFromHex(newColor),
+					  }
+					: s
+			)
 		)
+	}, [])
+
+	const handleNameChange = useCallback((id: number, newName: string) => {
+		setColorScales((prevScales) =>
+			prevScales.map((s) =>
+				s.id === id ? { ...s, name: newName, nameEdited: true } : s
+			)
+		)
+	}, [])
+
+	const resetScales = useCallback(() => {
+		setColorScales([makeScale(1, 0)])
+		setNextId(2)
 	}, [])
 
 	return (
 		<>
-			<h1 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
-				&#127912; Color Scale Generator
-			</h1>
+			<div className='flex flex-wrap items-center justify-between gap-2xs mb-2xs'>
+				<h1 className='text-step-1 sm:text-step-2 tracking-tight uppercase'>
+					&#127912; Color Scale Generator
+				</h1>
+				{(colorScales.length > 1 ||
+					colorScales[0]?.nameEdited ||
+					colorScales[0]?.color !==
+						colorUtils.defaultColorForIndex(0)) && (
+					<button
+						onClick={resetScales}
+						className='px-xs py-3xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 text-step--2 font-roboto-condensed'
+					>
+						Reset palette
+					</button>
+				)}
+			</div>
 			<section className='tracking-tight container p-s mb-xl bg-cream-50 rounded-lg border border-black-100 divide-y divide-gray-200'>
 				{colorScales.map((scale) => (
 					<div
@@ -44,8 +98,13 @@ const App = () => {
 						<div className='flex sm:flex-col gap-xs'>
 							<ColorInput
 								initialColor={scale.color}
+								name={scale.name}
+								autoName={colorUtils.nameFromHex(scale.color)}
 								onColorChange={(newColor) =>
 									handleColorChange(scale.id, newColor)
+								}
+								onNameChange={(newName) =>
+									handleNameChange(scale.id, newName)
 								}
 							/>
 							{colorScales.length > 1 && (
@@ -64,7 +123,7 @@ const App = () => {
 								</button>
 							)}
 						</div>
-						<ColorScale baseColor={scale.color} />
+						<ColorScale2 baseColor={scale.color} />
 					</div>
 				))}
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -93,7 +93,7 @@ const App = () => {
 				{colorScales.map((scale) => (
 					<div
 						key={scale.id}
-						className='py-4 flex flex-col sm:flex-row justify-between gap-s'
+						className='py-4 flex flex-col sm:flex-row sm:items-start justify-between gap-s'
 					>
 						<div className='flex sm:flex-col gap-xs'>
 							<ColorInput

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -19,7 +19,7 @@ interface Shade {
 }
 
 interface ColorData {
-	index: number
+	slug: string
 	shades: Shade[]
 }
 
@@ -44,6 +44,9 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 
 	const formattedCode = useMemo(() => {
 		const seenColors = new Set<string>()
+		const slugs = colorUtils.uniqueSlugs(
+			colorScales.map((scale) => scale.name)
+		)
 
 		const colorData: ColorData[] = colorScales
 			.map((scale: ColorScale, index: number): ColorData | null => {
@@ -68,7 +71,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 				}
 
 				return {
-					index: index + 1,
+					slug: slugs[index],
 					shades,
 				}
 			})
@@ -77,8 +80,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 		switch (themeFormat) {
 			case 'tailwind3': {
 				const tailwindColors = colorData
-					.map(({ index, shades }: ColorData) => {
-						return `  color${index}: {\n${shades
+					.map(({ slug, shades }: ColorData) => {
+						return `  ${slug}: {\n${shades
 							.map(
 								({ shade, color }: Shade) =>
 									`    ${shade}: "${color}"`
@@ -92,10 +95,10 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 
 			case 'tailwind4': {
 				const tailwind4Colors = colorData
-					.flatMap(({ index, shades }: ColorData) =>
+					.flatMap(({ slug, shades }: ColorData) =>
 						shades.map(
 							({ shade, color }: Shade) =>
-								`  --color-color${index}-${shade}: ${color};`
+								`  --color-${slug}-${shade}: ${color};`
 						)
 					)
 					.join('\n')
@@ -105,10 +108,10 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 
 			case 'css': {
 				const cssVars = colorData
-					.flatMap(({ index, shades }: ColorData) =>
+					.flatMap(({ slug, shades }: ColorData) =>
 						shades.map(
 							({ shade, color }: Shade) =>
-								`  --color${index}-${shade}: ${color};`
+								`  --${slug}-${shade}: ${color};`
 						)
 					)
 					.join('\n')

--- a/src/components/ColorInput.tsx
+++ b/src/components/ColorInput.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface ColorInputProps {
-	initialColor: string
+	color: string
 	name: string
 	autoName: string
 	onColorChange: (color: string) => void
@@ -9,20 +9,27 @@ interface ColorInputProps {
 }
 
 const ColorInput: React.FC<ColorInputProps> = ({
-	initialColor,
+	color,
 	name,
 	autoName,
 	onColorChange,
 	onNameChange,
 }) => {
-	const [color, setColor] = useState(initialColor.toUpperCase())
+	// Draft text for the hex field so the user can type an in-progress,
+	// not-yet-valid value. Resyncs whenever the committed color changes
+	// from outside (color picker, reset).
+	const [draft, setDraft] = useState(color.toUpperCase())
+
+	useEffect(() => {
+		setDraft(color.toUpperCase())
+	}, [color])
 
 	const updateColor = (newColor: string) => {
-		const formattedColor = newColor.toUpperCase()
-		setColor(formattedColor)
+		const formatted = newColor.toUpperCase()
+		setDraft(formatted)
 
-		if (/^#[0-9A-F]{6}$/.test(formattedColor)) {
-			onColorChange(formattedColor)
+		if (/^#[0-9A-F]{6}$/.test(formatted)) {
+			onColorChange(formatted)
 		}
 	}
 
@@ -55,7 +62,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
 						id={inputId}
 						aria-label='Color picker'
 						className='h-16 w-16 cursor-pointer absolute origin-center left-[-10px] top-[-10px]'
-						value={/^#[0-9A-F]{6}$/.test(color) ? color : '#3B82F6'}
+						value={/^#[0-9A-F]{6}$/.test(draft) ? draft : '#3B82F6'}
 						onChange={(e) => updateColor(e.target.value)}
 					/>
 				</div>
@@ -66,7 +73,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
 					aria-label='Hex code'
 					className='h-10 max-w-24 px-2xs rounded-sm border border-black-100'
 					placeholder='Enter hex code'
-					value={color}
+					value={draft}
 					onChange={(e) =>
 						updateColor(
 							e.target.value.startsWith('#')

--- a/src/components/ColorInput.tsx
+++ b/src/components/ColorInput.tsx
@@ -36,21 +36,23 @@ const ColorInput: React.FC<ColorInputProps> = ({
 	const inputId = `color-${autoName}`
 
 	return (
-		<div className='space-y-3xs'>
-			<label
-				htmlFor={`name-${inputId}`}
-				className='block text-step--2 font-roboto-condensed'
-			>
-				Name
-			</label>
-			<input
-				type='text'
-				id={`name-${inputId}`}
-				className='h-9 w-full max-w-44 px-2xs rounded-sm border border-black-100 text-step--2'
-				placeholder={autoName}
-				value={name}
-				onChange={(e) => onNameChange(e.target.value)}
-			/>
+		<div className='space-y-2xs'>
+			<div className='flex items-center gap-2xs'>
+				<label
+					htmlFor={`name-${inputId}`}
+					className='text-step--2 font-roboto-condensed shrink-0'
+				>
+					Name
+				</label>
+				<input
+					type='text'
+					id={`name-${inputId}`}
+					className='h-10 w-full max-w-36 px-2xs rounded-sm border border-black-100 text-step--2'
+					placeholder={autoName}
+					value={name}
+					onChange={(e) => onNameChange(e.target.value)}
+				/>
+			</div>
 
 			<label htmlFor={inputId} className='sr-only'>
 				Color hex value

--- a/src/components/ColorInput.tsx
+++ b/src/components/ColorInput.tsx
@@ -2,12 +2,18 @@ import { useState } from 'react'
 
 interface ColorInputProps {
 	initialColor: string
+	name: string
+	autoName: string
 	onColorChange: (color: string) => void
+	onNameChange: (name: string) => void
 }
 
 const ColorInput: React.FC<ColorInputProps> = ({
 	initialColor,
+	name,
+	autoName,
 	onColorChange,
+	onNameChange,
 }) => {
 	const [color, setColor] = useState(initialColor.toUpperCase())
 
@@ -20,16 +26,34 @@ const ColorInput: React.FC<ColorInputProps> = ({
 		}
 	}
 
+	const inputId = `color-${autoName}`
+
 	return (
-		<div>
-			<label htmlFor='colorInput' className='sr-only'>
-				Enter color below:
+		<div className='space-y-3xs'>
+			<label
+				htmlFor={`name-${inputId}`}
+				className='block text-step--2 font-roboto-condensed'
+			>
+				Name
+			</label>
+			<input
+				type='text'
+				id={`name-${inputId}`}
+				className='h-9 w-full max-w-44 px-2xs rounded-sm border border-black-100 text-step--2'
+				placeholder={autoName}
+				value={name}
+				onChange={(e) => onNameChange(e.target.value)}
+			/>
+
+			<label htmlFor={inputId} className='sr-only'>
+				Color hex value
 			</label>
 			<div className='flex items-center gap-2xs'>
-				<div className='rounded-full overflow-hidden border border-black-100 w-10 h-10 relative'>
+				<div className='rounded-full overflow-hidden border border-black-100 w-10 h-10 relative shrink-0'>
 					<input
 						type='color'
-						id='colorInput'
+						id={inputId}
+						aria-label='Color picker'
 						className='h-16 w-16 cursor-pointer absolute origin-center left-[-10px] top-[-10px]'
 						value={/^#[0-9A-F]{6}$/.test(color) ? color : '#3B82F6'}
 						onChange={(e) => updateColor(e.target.value)}
@@ -38,7 +62,8 @@ const ColorInput: React.FC<ColorInputProps> = ({
 				<input
 					type='text'
 					maxLength={7}
-					id='hexInput'
+					id={`hex-${inputId}`}
+					aria-label='Hex code'
 					className='h-10 max-w-24 px-2xs rounded-sm border border-black-100'
 					placeholder='Enter hex code'
 					value={color}

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { colorUtils } from '../utils/colorUtils'
 
 interface ColorScaleProps {
@@ -10,23 +10,48 @@ const ColorScale: React.FC<ColorScaleProps> = ({ baseColor }) => {
 		return colorUtils.generateShades(baseColor)
 	}, [baseColor])
 
+	const [copied, setCopied] = useState<string | null>(null)
+
+	const copyHex = (hex: string) => {
+		navigator.clipboard.writeText(hex)
+		setCopied(hex)
+		setTimeout(() => setCopied(null), 1200)
+	}
+
 	return (
 		<div className='flex flex-wrap gap-2xs'>
-			{shades.map((hexCode, index) => (
-				<div
-					key={index}
-					className='flex flex-col items-center w-[110px]'
-				>
-					<div
-						className='w-full h-16 rounded-sm color-scale-item border border-black-100 min-w-12'
-						style={{ backgroundColor: hexCode }}
-					/>
-					<span className='flex justify-between px-px w-full'>
-						<div>{colorUtils.shadeNumbers[index]}</div>
-						<div className='hex-code'>{hexCode}</div>
-					</span>
-				</div>
-			))}
+			{shades.map((hexCode, index) => {
+				const isCopied = copied === hexCode
+				return (
+					<button
+						key={index}
+						type='button'
+						onClick={() => copyHex(hexCode)}
+						aria-label={`Copy ${hexCode}`}
+						title={`Copy ${hexCode}`}
+						className='flex flex-col items-center w-[110px] group cursor-pointer focus:outline-hidden'
+					>
+						<div
+							className='relative w-full h-16 rounded-sm color-scale-item border border-black-100 min-w-12 group-hover:ring-2 group-hover:ring-black-500 group-focus:ring-2 group-focus:ring-blue-500'
+							style={{ backgroundColor: hexCode }}
+						>
+							<span
+								className={`absolute inset-0 flex items-center justify-center text-xs font-bold rounded-sm transition-opacity ${
+									isCopied
+										? 'opacity-100 bg-black-500/80 text-cream-100'
+										: 'opacity-0'
+								}`}
+							>
+								Copied!
+							</span>
+						</div>
+						<span className='flex justify-between px-px w-full'>
+							<span>{colorUtils.shadeNumbers[index]}</span>
+							<span className='hex-code'>{hexCode}</span>
+						</span>
+					</button>
+				)
+			})}
 		</div>
 	)
 }

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -32,7 +32,7 @@ const ColorScale: React.FC<ColorScaleProps> = ({ baseColor }) => {
 						className='flex flex-col items-center w-[110px] group cursor-pointer focus:outline-hidden'
 					>
 						<div
-							className='relative w-full h-16 rounded-sm color-scale-item border border-black-100 min-w-12 group-hover:ring-2 group-hover:ring-black-500 group-focus:ring-2 group-focus:ring-blue-500'
+							className='relative w-full h-12 rounded-sm color-scale-item border border-black-100 min-w-12 group-hover:ring-2 group-hover:ring-black-500 group-focus:ring-2 group-focus:ring-blue-500'
 							style={{ backgroundColor: hexCode }}
 						>
 							<span

--- a/src/components/ContrastChecker.tsx
+++ b/src/components/ContrastChecker.tsx
@@ -41,9 +41,15 @@ const tierInfo: Record<
 	},
 }
 
-const colorLabel = (c: ColorInfo) => `color${c.scaleIndex + 1}-${c.shade}`
-
 const ContrastChecker: React.FC<ContrastCheckerProps> = ({ colorScales }) => {
+	const slugs = useMemo(
+		() => colorUtils.uniqueSlugs(colorScales.map((s) => s.name)),
+		[colorScales]
+	)
+
+	const colorLabel = (c: ColorInfo) =>
+		`${slugs[c.scaleIndex] ?? 'color'}-${c.shade}`
+
 	const uniqueColors = useMemo(() => {
 		const colors: ColorInfo[] = []
 		const seen = new Set<string>()

--- a/src/components/ContrastChecker.tsx
+++ b/src/components/ContrastChecker.tsx
@@ -1,205 +1,248 @@
-import { useMemo } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import {
 	type ColorScale,
 	type ColorInfo,
 	colorUtils,
-	type ColorCombination,
 } from '../utils/colorUtils'
 
 interface ContrastCheckerProps {
 	colorScales: ColorScale[]
 }
 
+type Tier = 'AAA' | 'AA' | 'AA Large'
+
+interface Match {
+	foreground: ColorInfo
+	contrast: number
+	tier: Tier
+}
+
+const tierInfo: Record<
+	Tier,
+	{ badge: string; minSize: string; sampleClass: string; note: string }
+> = {
+	AAA: {
+		badge: 'text-black-400 bg-green-200',
+		minSize: 'Any size',
+		sampleClass: 'text-base',
+		note: 'Passes at any text size.',
+	},
+	AA: {
+		badge: 'text-black-400 bg-blue-100',
+		minSize: '16px / 12pt normal',
+		sampleClass: 'text-base',
+		note: 'Use at 16px or larger for body text.',
+	},
+	'AA Large': {
+		badge: 'text-black-400 bg-yellow-200',
+		minSize: '18.66px bold or 24px',
+		sampleClass: 'text-2xl font-bold',
+		note: 'Large text only — 24px, or 18.66px bold.',
+	},
+}
+
+const colorLabel = (c: ColorInfo) => `color${c.scaleIndex + 1}-${c.shade}`
+
 const ContrastChecker: React.FC<ContrastCheckerProps> = ({ colorScales }) => {
-	const accessibleCombinations = useMemo(() => {
-		const allColors: ColorInfo[] = []
-		const seenHexColors = new Set<string>()
+	const uniqueColors = useMemo(() => {
+		const colors: ColorInfo[] = []
+		const seen = new Set<string>()
 
 		colorScales.forEach((scale, scaleIndex) => {
-			const shades = colorUtils.generateShades(scale.color)
-			shades.forEach((hex, shadeIndex) => {
-				if (!seenHexColors.has(hex.toLowerCase())) {
-					seenHexColors.add(hex.toLowerCase())
-					allColors.push({
+			colorUtils.generateShades(scale.color).forEach((hex, shadeIndex) => {
+				const key = hex.toLowerCase()
+				if (!seen.has(key)) {
+					seen.add(key)
+					colors.push({
 						hex,
 						shade: colorUtils.shadeNumbers[shadeIndex],
 						scaleId: scale.id,
-						scaleIndex: scaleIndex,
+						scaleIndex,
 					})
 				}
 			})
 		})
 
-		const combinations: ColorCombination[] = []
-		for (let i = 0; i < allColors.length; i++) {
-			for (let j = i + 1; j < allColors.length; j++) {
-				const color1 = allColors[i]
-				const color2 = allColors[j]
-				const contrast = colorUtils.getContrastRatio(
-					color1.hex,
-					color2.hex
-				)
-
-				if (contrast >= 3.1) {
-					const meetsAA = contrast >= 4.5
-					const meetsAAA = contrast >= 7
-					const meetsAALarge = contrast >= 3.1
-
-					combinations.push({
-						color1,
-						color2,
-						contrast: Math.round(contrast * 10) / 10,
-						meetsAA,
-						meetsAAA,
-						meetsAALarge,
-					})
-				}
-			}
-		}
-
-		return combinations.sort((a, b) => b.contrast - a.contrast)
+		return colors
 	}, [colorScales])
+
+	const [bgHex, setBgHex] = useState<string | null>(null)
+
+	const background = useMemo(
+		() =>
+			uniqueColors.find((c) => c.hex === bgHex) ??
+			[...uniqueColors].sort((a, b) => b.shade - a.shade)[0] ??
+			null,
+		[uniqueColors, bgHex]
+	)
+
+	useEffect(() => {
+		if (background && background.hex !== bgHex) {
+			setBgHex(background.hex)
+		}
+	}, [background, bgHex])
+
+	const matches = useMemo(() => {
+		if (!background) return [] as Match[]
+
+		return uniqueColors
+			.filter((fg) => fg.hex !== background.hex)
+			.map((fg): Match | null => {
+				const ratio = colorUtils.getContrastRatio(
+					fg.hex,
+					background.hex
+				)
+				if (ratio < 3.1) return null
+				const tier: Tier =
+					ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'AA Large'
+				return {
+					foreground: fg,
+					contrast: Math.round(ratio * 10) / 10,
+					tier,
+				}
+			})
+			.filter((m): m is Match => m !== null)
+			.sort((a, b) => b.contrast - a.contrast)
+	}, [uniqueColors, background])
+
+	const grouped = useMemo(() => {
+		const groups: Record<Tier, Match[]> = {
+			AAA: [],
+			AA: [],
+			'AA Large': [],
+		}
+		matches.forEach((m) => groups[m.tier].push(m))
+		return groups
+	}, [matches])
+
+	if (!background) return null
 
 	return (
 		<div className='space-y-s mb-xl'>
-			<div className='bg-cream-50 rounded-lg border  border-black-100 overflow-hidden mt-s'>
-				<div className='p-xs bg-cream-200 border-b border-black-100'>
-					<p className='text-step--2'>
-						Showing all {accessibleCombinations.length} combinations
-						that meet minimum accessibility standards (≥3:1)
+			<div className='bg-cream-50 rounded-lg border border-black-100 overflow-hidden mt-s'>
+				<div
+					className='p-xs bg-cream-200 border-b border-black-100'
+					role='group'
+					aria-label='Choose a background color'
+				>
+					<p className='text-step--2 mb-2xs font-roboto-condensed uppercase tracking-tight'>
+						Pick a background color
 					</p>
+					<div className='flex flex-wrap gap-3xs'>
+						{uniqueColors.map((c) => {
+							const isSelected = c.hex === background.hex
+							return (
+								<button
+									key={c.hex}
+									type='button'
+									onClick={() => setBgHex(c.hex)}
+									aria-pressed={isSelected}
+									aria-label={`${colorLabel(c)}, ${c.hex}`}
+									title={`${colorLabel(c)} · ${c.hex}`}
+									className={`w-7 h-7 rounded-sm border transition-transform hover:scale-110 focus:outline-hidden focus:ring-2 focus:ring-blue-500 ${
+										isSelected
+											? 'border-black-500 ring-2 ring-black-500 scale-110'
+											: 'border-black-100'
+									}`}
+									style={{ backgroundColor: c.hex }}
+								/>
+							)
+						})}
+					</div>
 				</div>
 
-				<div className='overflow-x-auto max-h-128' tabIndex={0}>
-					<table className='w-full'>
-						<thead className='bg-cream-200 sticky top-0 text-left uppercase text-xs'>
-							<tr>
-								<th className='px-xs py-2xs'>Foreground</th>
-								<th className='px-xs py-2xs'>Background</th>
-								<th className='px-xs py-2xs'>Contrast</th>
-								<th className='px-xs py-2xs'>Level</th>
-								<th className='px-xs py-2xs'>Min Text Size</th>
-								<th className='px-xs py-2xs'>Preview</th>
-							</tr>
-						</thead>
-						<tbody className='divide-y divide-black-100'>
-							{accessibleCombinations.map((combo, index) => {
-								const getAccessibilityBadge = (
-									combo: ColorCombination
-								) => {
-									if (combo.meetsAAA)
-										return {
-											level: 'AAA',
-											class: 'text-black-400 bg-green-200',
-										}
-									if (combo.meetsAA)
-										return {
-											level: 'AA',
-											class: 'text-black-400 bg-blue-100',
-										}
-									if (combo.meetsAALarge)
-										return {
-											level: 'AA Large',
-											class: 'text-black-400 bg-yellow-200',
-										}
-									return {
-										level: 'Fail',
-										class: 'text-red-700 bg-red-100',
-									}
-								}
-
-								const getMinTextSize = (
-									combo: ColorCombination
-								) => {
-									if (combo.meetsAAA) return 'Any size'
-									if (combo.meetsAA) return '16px / 12pt'
-									if (combo.meetsAALarge) return '18px / 14pt'
-									return 'N/A'
-								}
-
-								const badge = getAccessibilityBadge(combo)
-								const minSize = getMinTextSize(combo)
-
-								return (
-									<tr
-										key={index}
-										className='hover:bg-cream-100'
-									>
-										<td className='px-xs py-2xs'>
-											<div className='flex items-center gap-2'>
-												<div
-													className='w-4 h-4 rounded-sm border border-gray-300'
-													style={{
-														backgroundColor:
-															combo.color1.hex,
-													}}
-												/>
-												<span className='text-sm'>
-													color
-													{combo.color1.scaleIndex +
-														1}
-													-{combo.color1.shade}
-												</span>
-											</div>
-										</td>
-										<td className='px-xs py-2xs'>
-											<div className='flex items-center gap-2'>
-												<div
-													className='w-4 h-4 rounded-sm border border-gray-300'
-													style={{
-														backgroundColor:
-															combo.color2.hex,
-													}}
-												/>
-												<span className='text-sm'>
-													color
-													{combo.color2.scaleIndex +
-														1}
-													-{combo.color2.shade}
-												</span>
-											</div>
-										</td>
-										<td className='px-xs py-2xs text-sm'>
-											{combo.contrast}:1
-										</td>
-										<td className='px-xs py-2xs'>
-											<span
-												className={`px-2xs py-3xs rounded-sm text-xs ${badge.class}`}
-											>
-												{badge.level}
-											</span>
-										</td>
-										<td className='px-xs py-2xs text-sm'>
-											{minSize}
-										</td>
-										<td className='px-xs py-2xs'>
-											<div
-												className='px-3 py-1 rounded-sm text-sm border text-center'
-												style={{
-													backgroundColor:
-														combo.color2.hex,
-													color: combo.color1.hex,
-												}}
-											>
-												Sample Text
-											</div>
-										</td>
-									</tr>
-								)
-							})}
-						</tbody>
-					</table>
+				<div className='p-xs flex flex-wrap items-center gap-2xs border-b border-black-100'>
+					<span className='text-step--2'>
+						Showing text colors that are legible on
+					</span>
+					<span className='inline-flex items-center gap-3xs px-2xs py-3xs rounded-sm border border-black-100 bg-cream-100 text-step--2'>
+						<span
+							className='w-4 h-4 rounded-xs border border-black-100'
+							style={{ backgroundColor: background.hex }}
+						/>
+						<span className='font-bold'>
+							{colorLabel(background)}
+						</span>
+						<span className='text-black-300'>{background.hex}</span>
+					</span>
+					<span className='text-step--2 text-black-300'>
+						· {matches.length} pass (≥3:1)
+					</span>
 				</div>
+
+				{matches.length === 0 ? (
+					<div className='p-s'>
+						<p className='text-red-700 text-step--2'>
+							No shades are legible on this background. Try a
+							lighter or darker background, or add a more
+							contrasting color scale.
+						</p>
+					</div>
+				) : (
+					<div className='p-xs space-y-s max-h-128 overflow-y-auto' tabIndex={0}>
+						{(['AAA', 'AA', 'AA Large'] as Tier[]).map((tier) => {
+							const items = grouped[tier]
+							if (items.length === 0) return null
+							const info = tierInfo[tier]
+							return (
+								<section key={tier} aria-label={`${tier} combinations`}>
+									<div className='flex flex-wrap items-baseline gap-2xs mb-2xs'>
+										<span
+											className={`px-2xs py-3xs rounded-sm text-xs font-bold ${info.badge}`}
+										>
+											{tier}
+										</span>
+										<span className='text-step--2 text-black-300'>
+											{items.length} · {info.note}
+										</span>
+									</div>
+									<ul className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2xs'>
+										{items.map((m) => (
+											<li
+												key={m.foreground.hex}
+												className='rounded-sm border border-black-100 overflow-hidden'
+											>
+												<div
+													className='px-xs py-2xs'
+													style={{
+														backgroundColor:
+															background.hex,
+														color: m.foreground.hex,
+													}}
+												>
+													<span
+														className={info.sampleClass}
+													>
+														The quick brown fox
+													</span>
+												</div>
+												<div className='flex items-center justify-between gap-2xs px-xs py-3xs bg-cream-100 text-step--2'>
+													<span className='flex items-center gap-3xs'>
+														<span
+															className='w-3 h-3 rounded-xs border border-black-100'
+															style={{
+																backgroundColor:
+																	m.foreground
+																		.hex,
+															}}
+														/>
+														{colorLabel(
+															m.foreground
+														)}
+													</span>
+													<span className='font-bold tabular-nums'>
+														{m.contrast}:1
+													</span>
+												</div>
+											</li>
+										))}
+									</ul>
+								</section>
+							)
+						})}
+					</div>
+				)}
 			</div>
-
-			{accessibleCombinations.length === 0 && (
-				<div className='p-s bg-red-50 border border-red-200 rounded-lg'>
-					<p className='text-red-700'>
-						No accessible color combinations found. Try adding more
-						contrasting colors or additional color scales.
-					</p>
-				</div>
-			)}
 		</div>
 	)
 }

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,6 +1,7 @@
 export interface ColorScale {
     id: number
     color: string
+    name: string
 }
 
 export interface ColorInfo {
@@ -55,6 +56,11 @@ export const colorUtils = {
     },
 
     hexToHSL(hex: string): string {
+        const { h, s, l } = colorUtils.hexToHSLValues(hex)
+        return `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, 1)`
+    },
+
+    hexToHSLValues(hex: string): { h: number; s: number; l: number } {
         let [r, g, b] = colorUtils.hexToRgb(hex).map((x) => x / 255)
         const max = Math.max(r, g, b)
         const min = Math.min(r, g, b)
@@ -78,9 +84,57 @@ export const colorUtils = {
             }
             h /= 6
         }
-        return `hsla(${Math.round(h * 360)}, ${Math.round(s * 100)}%, ${Math.round(
-            l * 100
-        )}%, 1)`
+        return { h: h * 360, s: s * 100, l: l * 100 }
+    },
+
+    // Maps a hex to a human-friendly hue name (e.g. "blue", "slate").
+    // Hand-rolled from HSL so there's no color-name dependency.
+    nameFromHex(hex: string): string {
+        const { h, s, l } = colorUtils.hexToHSLValues(hex)
+
+        if (l <= 8) return 'black'
+        if (l >= 95 && s <= 12) return 'white'
+        if (s <= 10) {
+            if (l <= 30) return 'charcoal'
+            if (l <= 55) return 'gray'
+            return 'silver'
+        }
+
+        const hues: [number, string][] = [
+            [15, 'red'],
+            [45, 'orange'],
+            [70, 'yellow'],
+            [160, 'green'],
+            [200, 'teal'],
+            [250, 'blue'],
+            [290, 'purple'],
+            [330, 'pink'],
+            [360, 'red'],
+        ]
+        const base = hues.find(([max]) => h <= max)?.[1] ?? 'color'
+        if (s <= 30) return `muted-${base}`
+        return base
+    },
+
+    slugify(name: string): string {
+        const slug = name
+            .toLowerCase()
+            .trim()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        return slug || 'color'
+    },
+
+    // Turns scale names into unique, export-safe slugs, preserving order.
+    // Collisions get a numeric suffix: blue, blue-2, blue-3.
+    uniqueSlugs(names: string[]): string[] {
+        const counts = new Map<string, number>()
+        return names.map((name) => {
+            const base = colorUtils.slugify(name)
+            const seen = counts.get(base) ?? 0
+            counts.set(base, seen + 1)
+            return seen === 0 ? base : `${base}-${seen + 1}`
+        })
     },
 
     mixColors(
@@ -91,6 +145,24 @@ export const colorUtils = {
         return color1.map((c, i) =>
             Math.round(c * (1 - weight) + color2[i] * weight)
         ) as [number, number, number]
+    },
+
+    hslToHex(h: number, s: number, l: number): string {
+        const sFrac = s / 100
+        const lFrac = l / 100
+        const k = (n: number) => (n + h / 30) % 12
+        const a = sFrac * Math.min(lFrac, 1 - lFrac)
+        const f = (n: number) =>
+            lFrac - a * Math.max(-1, Math.min(k(n) - 3, 9 - k(n), 1))
+        return colorUtils.rgbToHex(f(0) * 255, f(8) * 255, f(4) * 255)
+    },
+
+    // A distinct starting color for the Nth scale, so new scales don't
+    // collapse into each other in the dedupe. Walks the hue wheel by a
+    // golden-angle step for good visual separation.
+    defaultColorForIndex(index: number): string {
+        const hue = (210 + index * 137.508) % 360
+        return colorUtils.hslToHex(hue, 65, 60)
     },
 
     generateShades(baseColor: string): string[] {


### PR DESCRIPTION
Summary:

- Inlined the name label + input — "Name" now sits on the same row as its field (flex items-center), mirroring the picker + hex row directly below it. Both control rows are equalized at h-10, so the left column reads as two clean, matched rows.
- 
- Aligned and sized the swatches — the row is now explicitly top-aligned (sm:items-start) so the swatch strip starts level with the controls, and I shrank the swatch color blocks from h-16 → h-12 so they read proportionate to the compact controls rather than towering over them. At full container width the picker/hex row lines up with the swatch label row.