### PR TITLE
feat: add Markdown style-guide export and scroll the snippet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ Three things the app does, top to bottom on one page:
 2. **Check contrast.** Every unique shade across every scale is paired against
    every other, and combinations meeting at least 3:1 are listed with their
    WCAG level (AAA / AA / AA Large), minimum text size, and a live preview.
-3. **Export code.** The scales are emitted as **CSS variables**, **Tailwind 3.4**
-   theme colors, or **Tailwind 4.1** `@theme` tokens, in **hex / HSL / RGB**,
-   with one-click copy.
+3. **Export.** The scales are emitted as **CSS variables**, **Tailwind 3.4**
+   theme colors, **Tailwind 4.1** `@theme` tokens (in **hex / HSL / RGB**), or a
+   **Markdown style guide** (a Hex + HSL table per color with WCAG
+   text-on-white/black notes), with one-click copy.
 
 Deployed at <https://tools.myol-creative.com/>. There is no backend — it's a
 fully static Astro site with a client-rendered React island.
@@ -69,7 +70,7 @@ src/
     ColorInput.tsx        Hex text field + native color picker for one scale. Validates #RRGGBB.
     ColorScale.tsx        Renders the 10 swatches (50–900) for one base color.
     ContrastChecker.tsx   Builds & sorts all accessible shade pairings into a table.
-    CodeBlock.tsx         Theme/color-format selectors + Prism-highlighted, copyable export.
+    CodeBlock.tsx         Format/color-format selectors + Prism-highlighted, copyable export (CSS / Tailwind / Markdown).
   utils/
     colorUtils.ts         All color math + shared types. The one place logic lives.
   styles/
@@ -256,7 +257,8 @@ the live page reflects the merged commit before calling anything fixed.
   [CodeBlock](./src/components/CodeBlock.tsx) and
   [ContrastChecker](./src/components/ContrastChecker.tsx) labels go through
   `uniqueSlugs` so naming stays consistent. (This replaced the old positional
-  `color1`/`color2` naming.)
+  `color1`/`color2` naming.) The Markdown export uses the human `name`
+  (capitalized) for section headings rather than the slug.
 - **Shade** — one step on a scale, keyed by `shadeNumbers` `50 100 200 300 400
   500 600 700 800 900`. **500 is the unmodified base color.** Below 500 mixes
   toward white, above 500 toward black.
@@ -267,9 +269,12 @@ the live page reflects the merged commit before calling anything fixed.
   for the preview, not the ratio.
 - **Contrast levels** — `AAA` (≥7:1), `AA` (≥4.5:1), `AA Large` (≥3.1:1). The
   table only lists pairs ≥3:1; anything lower is dropped, not shown as "Fail".
-- **Theme format vs. color format** — *theme format* is the output syntax
-  (`css` variables, `tailwind3`, `tailwind4`); *color format* is the value
-  encoding (`hex`, `hsl`, `rgb`). They're independent selectors in `CodeBlock`.
+- **Format vs. color format** — *format* is the output syntax (`css` variables,
+  `tailwind3`, `tailwind4`, `markdown`); *color format* is the value encoding
+  (`hex`, `hsl`, `rgb`). Independent selectors in `CodeBlock`, except the color
+  format is hidden for `markdown` (which always emits a Hex + HSL table). The
+  Markdown branch builds from raw-hex shade data, not the `convertColor`
+  pipeline the code formats use.
 
 ---
 

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -3,22 +3,24 @@ import { colorUtils, type ColorScale } from '../utils/colorUtils'
 import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
+import 'prismjs/components/prism-markdown'
 
 interface CodeBlockProps {
 	colorScales: ColorScale[]
 }
 
-type ThemeFormat = 'tailwind3' | 'tailwind4' | 'css'
+type ThemeFormat = 'tailwind3' | 'tailwind4' | 'css' | 'markdown'
 type ColorFormat = 'hex' | 'hsl' | 'rgb'
 
 type ShadeNumber = (typeof colorUtils.shadeNumbers)[number]
 
 interface Shade {
 	shade: ShadeNumber
-	color: string
+	hex: string
 }
 
 interface ColorData {
+	name: string
 	slug: string
 	shades: Shade[]
 }
@@ -29,10 +31,11 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 	const [themeFormat, setThemeFormat] = useState<ThemeFormat>('css')
 	const [colorFormat, setColorFormat] = useState<ColorFormat>('hex')
 
+	const isMarkdown = themeFormat === 'markdown'
+	const language = isMarkdown ? 'markdown' : 'css'
+
 	const convertColor = (hex: string, format: ColorFormat): string => {
 		switch (format) {
-			case 'hex':
-				return hex
 			case 'hsl':
 				return colorUtils.hexToHSL(hex)
 			case 'rgb':
@@ -42,87 +45,133 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 		}
 	}
 
-	const formattedCode = useMemo(() => {
+	// Raw, deduped shade data in hex — the single source the formatters build on.
+	const colorData = useMemo<ColorData[]>(() => {
 		const seenColors = new Set<string>()
-		const slugs = colorUtils.uniqueSlugs(
-			colorScales.map((scale) => scale.name)
-		)
+		const slugs = colorUtils.uniqueSlugs(colorScales.map((s) => s.name))
 
-		const colorData: ColorData[] = colorScales
-			.map((scale: ColorScale, index: number): ColorData | null => {
+		return colorScales
+			.map((scale, index): ColorData | null => {
 				const shades: Shade[] = colorUtils
 					.generateShades(scale.color)
-					.map(
-						(shade: string, i: number): Shade => ({
-							shade: colorUtils.shadeNumbers[i],
-							color: convertColor(shade, colorFormat),
-						})
-					)
-					.filter(({ color }: Shade) => {
-						if (seenColors.has(color)) {
-							return false
-						}
-						seenColors.add(color)
+					.map((hex, i) => ({
+						shade: colorUtils.shadeNumbers[i],
+						hex,
+					}))
+					.filter(({ hex }) => {
+						if (seenColors.has(hex)) return false
+						seenColors.add(hex)
 						return true
 					})
 
-				if (shades.length === 0) {
-					return null
-				}
-
+				if (shades.length === 0) return null
 				return {
+					name: scale.name.trim() || slugs[index],
 					slug: slugs[index],
 					shades,
 				}
 			})
 			.filter((item): item is ColorData => item !== null)
+	}, [colorScales])
 
+	const formattedCode = useMemo(() => {
 		switch (themeFormat) {
 			case 'tailwind3': {
-				const tailwindColors = colorData
-					.map(({ slug, shades }: ColorData) => {
-						return `  ${slug}: {\n${shades
-							.map(
-								({ shade, color }: Shade) =>
-									`    ${shade}: "${color}"`
-							)
-							.join(',\n')}\n  }`
-					})
+				const body = colorData
+					.map(
+						({ slug, shades }) =>
+							`  ${slug}: {\n${shades
+								.map(
+									({ shade, hex }) =>
+										`    ${shade}: "${convertColor(
+											hex,
+											colorFormat
+										)}"`
+								)
+								.join(',\n')}\n  }`
+					)
 					.join(',\n')
-
-				return `colors: {\n${tailwindColors}\n}`
+				return `colors: {\n${body}\n}`
 			}
 
 			case 'tailwind4': {
-				const tailwind4Colors = colorData
-					.flatMap(({ slug, shades }: ColorData) =>
+				const body = colorData
+					.flatMap(({ slug, shades }) =>
 						shades.map(
-							({ shade, color }: Shade) =>
-								`  --color-${slug}-${shade}: ${color};`
+							({ shade, hex }) =>
+								`  --color-${slug}-${shade}: ${convertColor(
+									hex,
+									colorFormat
+								)};`
 						)
 					)
 					.join('\n')
-
-				return `@theme {\n${tailwind4Colors}\n}`
+				return `@theme {\n${body}\n}`
 			}
 
 			case 'css': {
-				const cssVars = colorData
-					.flatMap(({ slug, shades }: ColorData) =>
+				const body = colorData
+					.flatMap(({ slug, shades }) =>
 						shades.map(
-							({ shade, color }: Shade) =>
-								`  --${slug}-${shade}: ${color};`
+							({ shade, hex }) =>
+								`  --${slug}-${shade}: ${convertColor(
+									hex,
+									colorFormat
+								)};`
 						)
 					)
 					.join('\n')
+				return `:root {\n${body}\n}`
+			}
 
-				return `:root {\n${cssVars}\n}`
+			case 'markdown': {
+				const capitalize = (s: string) =>
+					s.charAt(0).toUpperCase() + s.slice(1)
+
+				const sections = colorData.map(({ name, shades }) => {
+					const rows = shades
+						.map(
+							({ shade, hex }) =>
+								`| ${shade} | \`${hex}\` | \`${colorUtils.hexToHSL(
+									hex
+								)}\` |`
+						)
+						.join('\n')
+
+					const safe = colorUtils.textSafeShades(
+						shades.map((s) => s.hex)
+					)
+
+					return [
+						`## ${capitalize(name)}`,
+						'',
+						'| Shade | Hex | HSL |',
+						'| ----: | --- | --- |',
+						rows,
+						'',
+						`- **Text on white** (AA): ${colorUtils.formatShadeRanges(
+							safe.onWhite
+						)}`,
+						`- **Text on black** (AA): ${colorUtils.formatShadeRanges(
+							safe.onBlack
+						)}`,
+					].join('\n')
+				})
+
+				return [
+					'# Color Palette',
+					'',
+					'Generated color scales. Accessibility notes list the shades',
+					'that pass WCAG AA (≥4.5:1) as text on a white or black background.',
+					'',
+					...sections,
+				].join('\n\n')
 			}
 
 			default:
 				return ''
 		}
-	}, [colorScales, themeFormat, colorFormat])
+	}, [colorData, themeFormat, colorFormat])
 
 	useEffect(() => {
 		setIsClient(true)
@@ -132,7 +181,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 		if (isClient) {
 			Prism.highlightAll()
 		}
-	}, [formattedCode, isClient])
+	}, [formattedCode, isClient, language])
 
 	useEffect(() => {
 		setIsCopied(false)
@@ -155,7 +204,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 							htmlFor='theme format'
 							className='block text-step--2 font-roboto-condensed'
 						>
-							Theme Format
+							Format
 						</label>
 						<select
 							id='theme format'
@@ -168,35 +217,38 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 							<option value='css'>CSS Variables</option>
 							<option value='tailwind3'>Tailwind 3.4</option>
 							<option value='tailwind4'>Tailwind 4.1</option>
+							<option value='markdown'>Style Guide (Markdown)</option>
 						</select>
 					</div>
 
-					<div className='space-y-3xs'>
-						<label
-							htmlFor='color format'
-							className='block text-step--2 font-roboto-condensed'
-						>
-							Color Format
-						</label>
-						<select
-							id='color format'
-							value={colorFormat}
-							onChange={(e) =>
-								setColorFormat(e.target.value as ColorFormat)
-							}
-							className='px-xs py-2xs border border-black-100 rounded-sm bg-cream-50 text-step--2 focus:outline-hidden focus:ring-2 focus:ring-blue-500'
-						>
-							<option value='hex'>Hex</option>
-							<option value='hsl'>HSL</option>
-							<option value='rgb'>RGB</option>
-						</select>
-					</div>
+					{!isMarkdown && (
+						<div className='space-y-3xs'>
+							<label
+								htmlFor='color format'
+								className='block text-step--2 font-roboto-condensed'
+							>
+								Color Format
+							</label>
+							<select
+								id='color format'
+								value={colorFormat}
+								onChange={(e) =>
+									setColorFormat(e.target.value as ColorFormat)
+								}
+								className='px-xs py-2xs border border-black-100 rounded-sm bg-cream-50 text-step--2 focus:outline-hidden focus:ring-2 focus:ring-blue-500'
+							>
+								<option value='hex'>Hex</option>
+								<option value='hsl'>HSL</option>
+								<option value='rgb'>RGB</option>
+							</select>
+						</div>
+					)}
 				</div>
 			</div>
-			<div className='relative p-s bg-[#2d2d2d] text-cream-100'>
+			<div className='relative bg-[#2d2d2d] text-cream-100'>
 				<button
 					onClick={copyToClipboard}
-					className={`absolute top-6 right-6 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
+					className={`absolute top-6 right-6 z-10 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
 						isCopied
 							? 'bg-green-200 text-green-800'
 							: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
@@ -204,10 +256,10 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 				>
 					{isCopied ? 'Code Copied!' : 'Copy Code'}
 				</button>
-				<pre>
+				<pre className='p-s max-h-128 overflow-auto'>
 					<code
 						className={`text-sm sm:text-lg ${
-							isClient ? 'language-css' : ''
+							isClient ? `language-${language}` : ''
 						}`}
 					>
 						{formattedCode}

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -203,5 +203,48 @@ export const colorUtils = {
         const darkest = Math.min(lum1, lum2)
 
         return (brightest + 0.05) / (darkest + 0.05)
-    }
+    },
+
+    // Which shades pass WCAG AA (>=4.5:1) as text on white and on black.
+    // Used by the style-guide export to annotate each scale.
+    textSafeShades(shadeHexes: string[]): {
+        onWhite: number[]
+        onBlack: number[]
+    } {
+        const onWhite: number[] = []
+        const onBlack: number[] = []
+        shadeHexes.forEach((hex, i) => {
+            const shade = colorUtils.shadeNumbers[i]
+            if (colorUtils.getContrastRatio(hex, '#FFFFFF') >= 4.5) {
+                onWhite.push(shade)
+            }
+            if (colorUtils.getContrastRatio(hex, '#000000') >= 4.5) {
+                onBlack.push(shade)
+            }
+        })
+        return { onWhite, onBlack }
+    },
+
+    // Compresses a sorted list of shade numbers into a readable range string,
+    // e.g. [600,700,800,900] -> "600-900", [50,200,900] -> "50, 200, 900".
+    formatShadeRanges(shades: number[]): string {
+        if (shades.length === 0) return 'none'
+        const order = colorUtils.shadeNumbers as readonly number[]
+        const parts: string[] = []
+        let start = shades[0]
+        let prev = shades[0]
+        const isNext = (a: number, b: number) =>
+            order.indexOf(b) === order.indexOf(a) + 1
+        for (let i = 1; i <= shades.length; i++) {
+            const cur = shades[i]
+            if (i < shades.length && isNext(prev, cur)) {
+                prev = cur
+                continue
+            }
+            parts.push(start === prev ? `${start}` : `${start}-${prev}`)
+            start = cur
+            prev = cur
+        }
+        return parts.join(', ')
+    },
 }


### PR DESCRIPTION
Summary:

Adds a "Style Guide (Markdown)" export: per-color Hex+HSL shade table with WCAG text-on-white/black notes.
Markdown always emits hex+HSL; the color-format selector is hidden in that mode.
Refactors CodeBlock to format each output (CSS / Tailwind 3 / Tailwind 4 / Markdown) from one raw-hex dataset.
Caps the snippet at max-h-128 with scroll + sticky copy button so it no longer grows unbounded.

Test plan:

npm run build passes.
Playwright (manual): all four formats produce correct output; HSL applies to code formats; Markdown table + a11y notes correct; color-format hidden in Markdown; snippet scrolls.