### PR TITLE
feat: shareable palette via URL hash + autosave

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ about architecture or conventions.
 scales from base colors, check WCAG contrast across all generated shades, and
 export the result as ready-to-paste code.
 
-Three things the app does, top to bottom on one page:
+What the app does, top to bottom on one page:
 
 1. **Generate scales.** Enter one or more base hex colors; each expands into a
    10-step shade ramp (50–900).
@@ -24,6 +24,10 @@ Three things the app does, top to bottom on one page:
    theme colors, **Tailwind 4.1** `@theme` tokens (in **hex / HSL / RGB**), or a
    **Markdown style guide** (a Hex + HSL table per color with WCAG
    text-on-white/black notes), with one-click copy.
+4. **Share.** The palette lives in the URL hash (`#p=name:hex,…`), so editing
+   updates the link live and a shared link reopens the exact palette. Also
+   autosaved to `localStorage` (written, but not auto-restored — the URL or the
+   default wins on load). See the **Palette sharing** glossary entry.
 
 Deployed at <https://tools.myol-creative.com/>. There is no backend — it's a
 fully static Astro site with a client-rendered React island.
@@ -275,6 +279,15 @@ the live page reflects the merged commit before calling anything fixed.
   format is hidden for `markdown` (which always emits a Hex + HSL table). The
   Markdown branch builds from raw-hex shade data, not the `convertColor`
   pipeline the code formats use.
+- **Palette sharing** — the palette serializes to `name:hex,…`
+  (`colorUtils.encodePalette` / `decodePalette`) and lives in the URL hash under
+  the `#p=` prefix. `App` reads it once on mount (a valid hash wins over the
+  default; `localStorage` is written but **not** auto-restored), then a
+  `colorScales` effect live-syncs back to the hash via `history.replaceState`
+  (no history spam) and to `localStorage`. A `hydrated` ref gates that effect so
+  it can't overwrite the hash before the initial read. Shared scales load with
+  `nameEdited: true` (the name is authored, so a later recolor won't rename it).
+  Malformed pairs are dropped; if nothing valid decodes, the default loads.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -69,3 +69,7 @@ color (a `500`), auto-named via `colorUtils.nameFromHex`.
   `feature/contrast-picker-redesign`). Editable, hue-auto-named scales; names
   flow into the export (slugified + de-duped) and contrast labels; varied
   default color per new scale; click-to-copy swatch hex; reset-palette control.
+- **Shareable / persistent palette** (branch `feature/shareable-palette`).
+  Palette serialized to the URL hash (`#p=name:hex,…`) with live sync + a copy
+  link button; `localStorage` autosave (write-only, not auto-restored). URL wins
+  over default on load; malformed hashes fall back to the default.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { colorUtils, type ColorScale } from '../utils/colorUtils'
 import ColorInput from './ColorInput'
 import ColorScale2 from './ColorScale'
@@ -10,6 +10,9 @@ interface ScaleState extends ColorScale {
 	nameEdited: boolean
 }
 
+const STORAGE_KEY = 'color-scale-generator:palette'
+const HASH_PREFIX = '#p='
+
 const makeScale = (id: number, index: number): ScaleState => {
 	const color = colorUtils.defaultColorForIndex(index)
 	return {
@@ -20,11 +23,61 @@ const makeScale = (id: number, index: number): ScaleState => {
 	}
 }
 
+const defaultScales = (): ScaleState[] => [makeScale(1, 0)]
+
+// Build ScaleState rows from decoded {name, color} entries. A shared name is
+// treated as authored (nameEdited), so it isn't overwritten by hue auto-naming.
+const scalesFromEntries = (
+	entries: { name: string; color: string }[]
+): ScaleState[] =>
+	entries.map((entry, i) => ({
+		id: i + 1,
+		color: entry.color,
+		name: entry.name,
+		nameEdited: true,
+	}))
+
+// Reads a palette from the URL hash, if present and valid. Client-only.
+const readHashPalette = (): ScaleState[] | null => {
+	if (typeof window === 'undefined') return null
+	const hash = window.location.hash
+	if (!hash.startsWith(HASH_PREFIX)) return null
+	const encoded = decodeURIComponent(hash.slice(HASH_PREFIX.length))
+	const entries = colorUtils.decodePalette(encoded)
+	return entries.length > 0 ? scalesFromEntries(entries) : null
+}
+
 const App = () => {
-	const [colorScales, setColorScales] = useState<ScaleState[]>([
-		makeScale(1, 0),
-	])
+	const [colorScales, setColorScales] = useState<ScaleState[]>(defaultScales)
 	const [nextId, setNextId] = useState(2)
+	// Becomes true after the initial URL read, so the sync effect doesn't
+	// clobber the hash before we've had a chance to load from it.
+	const hydrated = useRef(false)
+
+	// On mount: a palette in the URL wins; otherwise keep the default.
+	// (Autosave is written below but intentionally not auto-restored.)
+	useEffect(() => {
+		const fromHash = readHashPalette()
+		if (fromHash) {
+			setColorScales(fromHash)
+			setNextId(fromHash.length + 1)
+		}
+		hydrated.current = true
+	}, [])
+
+	// Live-sync to the URL hash (replaceState, so edits don't spam history)
+	// and autosave to localStorage. Runs only after the initial load.
+	useEffect(() => {
+		if (!hydrated.current) return
+		const encoded = colorUtils.encodePalette(colorScales)
+		const url = `${window.location.pathname}${window.location.search}${HASH_PREFIX}${encoded}`
+		window.history.replaceState(null, '', url)
+		try {
+			window.localStorage.setItem(STORAGE_KEY, encoded)
+		} catch {
+			// localStorage may be unavailable (private mode); ignore.
+		}
+	}, [colorScales])
 
 	const addColorScale = useCallback(() => {
 		setColorScales((prevScales) => [
@@ -67,8 +120,15 @@ const App = () => {
 	}, [])
 
 	const resetScales = useCallback(() => {
-		setColorScales([makeScale(1, 0)])
+		setColorScales(defaultScales())
 		setNextId(2)
+	}, [])
+
+	const [linkCopied, setLinkCopied] = useState(false)
+	const copyShareLink = useCallback(() => {
+		navigator.clipboard.writeText(window.location.href)
+		setLinkCopied(true)
+		setTimeout(() => setLinkCopied(false), 2000)
 	}, [])
 
 	return (
@@ -77,17 +137,29 @@ const App = () => {
 				<h1 className='text-step-1 sm:text-step-2 tracking-tight uppercase'>
 					&#127912; Color Scale Generator
 				</h1>
-				{(colorScales.length > 1 ||
-					colorScales[0]?.nameEdited ||
-					colorScales[0]?.color !==
-						colorUtils.defaultColorForIndex(0)) && (
+				<div className='flex items-center gap-2xs'>
 					<button
-						onClick={resetScales}
-						className='px-xs py-3xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 text-step--2 font-roboto-condensed'
+						onClick={copyShareLink}
+						className={`px-xs py-3xs border rounded-sm text-step--2 font-roboto-condensed ${
+							linkCopied
+								? 'border-green-600 bg-green-200 text-green-800'
+								: 'border-black-100 hover:bg-black-500 hover:text-cream-100'
+						}`}
 					>
-						Reset palette
+						{linkCopied ? 'Link copied!' : 'Copy share link'}
 					</button>
-				)}
+					{(colorScales.length > 1 ||
+						colorScales[0]?.nameEdited ||
+						colorScales[0]?.color !==
+							colorUtils.defaultColorForIndex(0)) && (
+						<button
+							onClick={resetScales}
+							className='px-xs py-3xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 text-step--2 font-roboto-condensed'
+						>
+							Reset palette
+						</button>
+					)}
+				</div>
 			</div>
 			<section className='tracking-tight container p-s mb-xl bg-cream-50 rounded-lg border border-black-100 divide-y divide-gray-200'>
 				{colorScales.map((scale) => (

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -137,6 +137,39 @@ export const colorUtils = {
         })
     },
 
+    // --- Shareable palette serialization ---
+    // A palette is encoded for the URL hash as `name:hex` pairs joined by
+    // commas, e.g. `blue:5799DB,brand:E11D48`. Names are slugified and hexes
+    // are stripped of '#'. Round-trips through encode/decode.
+
+    encodePalette(scales: { name: string; color: string }[]): string {
+        return scales
+            .map(({ name, color }) => {
+                const hex = color.replace('#', '').toUpperCase()
+                return `${colorUtils.slugify(name)}:${hex}`
+            })
+            .join(',')
+    },
+
+    // Parses the encoded string back into entries, dropping any malformed
+    // pair. Returns [] when nothing valid is found.
+    decodePalette(encoded: string): { name: string; color: string }[] {
+        if (!encoded) return []
+        return encoded
+            .split(',')
+            .map((pair) => {
+                const [rawName, rawHex] = pair.split(':')
+                if (!rawHex) return null
+                const hex = rawHex.trim()
+                if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null
+                const name = colorUtils.slugify(rawName ?? '')
+                return { name, color: `#${hex.toUpperCase()}` }
+            })
+            .filter(
+                (e): e is { name: string; color: string } => e !== null
+            )
+    },
+
     mixColors(
         color1: [number, number, number],
         color2: [number, number, number],


### PR DESCRIPTION
Summary:

The palette is now serialized to the URL so handoff is a link:

- encodePalette/decodePalette in colorUtils turn scales into a compact name:hex,... string (validated; malformed pairs dropped)
- App reads the palette from the #p= hash once on mount (URL wins over the default); localStorage is written for autosave but intentionally not auto-restored, so load is predictable
- a colorScales effect live-syncs to the hash via history.replaceState (no history spam) and to localStorage; a hydrated ref gates it so it can't clobber the hash before the initial read
- shared scales load as authored (nameEdited) so a later recolor won't rename them
- 'Copy share link' button with confirmation in the header

Update CLAUDE.md (app intro + Palette sharing glossary) and PLAN.md.