### PR TITLE
feat: add W3C Design Tokens (DTCG) JSON export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,10 @@ What the app does, top to bottom on one page:
    every other, and combinations meeting at least 3:1 are listed with their
    WCAG level (AAA / AA / AA Large), minimum text size, and a live preview.
 3. **Export.** The scales are emitted as **CSS variables**, **Tailwind 3.4**
-   theme colors, **Tailwind 4.1** `@theme` tokens (in **hex / HSL / RGB**), or a
+   theme colors, **Tailwind 4.1** `@theme` tokens (in **hex / HSL / RGB**), a
    **Markdown style guide** (a Hex + HSL table per color with WCAG
-   text-on-white/black notes), with one-click copy.
+   text-on-white/black notes), or **W3C Design Tokens (DTCG) JSON** (always hex),
+   with one-click copy.
 4. **Share.** The palette lives in the URL hash (`#p=name:hex,…`), so editing
    updates the link live and a shared link reopens the exact palette. Also
    autosaved to `localStorage` (written, but not auto-restored — the URL or the
@@ -274,11 +275,14 @@ the live page reflects the merged commit before calling anything fixed.
 - **Contrast levels** — `AAA` (≥7:1), `AA` (≥4.5:1), `AA Large` (≥3.1:1). The
   table only lists pairs ≥3:1; anything lower is dropped, not shown as "Fail".
 - **Format vs. color format** — *format* is the output syntax (`css` variables,
-  `tailwind3`, `tailwind4`, `markdown`); *color format* is the value encoding
-  (`hex`, `hsl`, `rgb`). Independent selectors in `CodeBlock`, except the color
-  format is hidden for `markdown` (which always emits a Hex + HSL table). The
-  Markdown branch builds from raw-hex shade data, not the `convertColor`
-  pipeline the code formats use.
+  `tailwind3`, `tailwind4`, `markdown`, `tokens`); *color format* is the value
+  encoding (`hex`, `hsl`, `rgb`). Independent selectors in `CodeBlock`, except
+  the color format is hidden for the fixed-value formats (`markdown` → Hex + HSL
+  table; `tokens` → always hex). Those two build from raw-hex shade data, not the
+  `convertColor` pipeline the code formats use. `tokens` emits W3C Design Tokens
+  (DTCG): `{ slug: { shade: { $type: "color", $value: "#hex" } } }`, keyed by the
+  de-duped slug. The Prism language switches `css` / `markdown` / `json` by
+  format.
 - **Palette sharing** — the palette serializes to `name:hex,…`
   (`colorUtils.encodePalette` / `decodePalette`) and lives in the URL hash under
   the `#p=` prefix. `App` reads it once on mount (a valid hash wins over the

--- a/PLAN.md
+++ b/PLAN.md
@@ -73,3 +73,7 @@ color (a `500`), auto-named via `colorUtils.nameFromHex`.
   Palette serialized to the URL hash (`#p=name:hex,…`) with live sync + a copy
   link button; `localStorage` autosave (write-only, not auto-restored). URL wins
   over default on load; malformed hashes fall back to the default.
+- **Design Tokens (DTCG) JSON export** (branch `feature/design-tokens-export`).
+  New `tokens` format in `CodeBlock` emitting W3C Design Tokens
+  (`{ slug: { shade: { $type, $value } } }`, always hex) for Style Dictionary /
+  Tokens Studio / Figma; JSON syntax-highlighted; color-format selector hidden.

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -4,12 +4,13 @@ import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markdown'
+import 'prismjs/components/prism-json'
 
 interface CodeBlockProps {
 	colorScales: ColorScale[]
 }
 
-type ThemeFormat = 'tailwind3' | 'tailwind4' | 'css' | 'markdown'
+type ThemeFormat = 'tailwind3' | 'tailwind4' | 'css' | 'markdown' | 'tokens'
 type ColorFormat = 'hex' | 'hsl' | 'rgb'
 
 type ShadeNumber = (typeof colorUtils.shadeNumbers)[number]
@@ -31,8 +32,14 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 	const [themeFormat, setThemeFormat] = useState<ThemeFormat>('css')
 	const [colorFormat, setColorFormat] = useState<ColorFormat>('hex')
 
-	const isMarkdown = themeFormat === 'markdown'
-	const language = isMarkdown ? 'markdown' : 'css'
+	// Formats whose values are fixed (not driven by the color-format selector).
+	const fixedColorFormat = themeFormat === 'markdown' || themeFormat === 'tokens'
+	const language =
+		themeFormat === 'markdown'
+			? 'markdown'
+			: themeFormat === 'tokens'
+			? 'json'
+			: 'css'
 
 	const convertColor = (hex: string, format: ColorFormat): string => {
 		switch (format) {
@@ -168,6 +175,22 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 				].join('\n\n')
 			}
 
+			case 'tokens': {
+				// W3C Design Tokens (DTCG) format: groups keyed by slug, each
+				// shade a { $type: "color", $value: "#hex" } token. Always hex.
+				const tokens: Record<
+					string,
+					Record<string, { $type: 'color'; $value: string }>
+				> = {}
+				colorData.forEach(({ slug, shades }) => {
+					tokens[slug] = {}
+					shades.forEach(({ shade, hex }) => {
+						tokens[slug][shade] = { $type: 'color', $value: hex }
+					})
+				})
+				return JSON.stringify(tokens, null, 2)
+			}
+
 			default:
 				return ''
 		}
@@ -218,10 +241,11 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 							<option value='tailwind3'>Tailwind 3.4</option>
 							<option value='tailwind4'>Tailwind 4.1</option>
 							<option value='markdown'>Style Guide (Markdown)</option>
+							<option value='tokens'>Design Tokens (JSON)</option>
 						</select>
 					</div>
 
-					{!isMarkdown && (
+					{!fixedColorFormat && (
 						<div className='space-y-3xs'>
 							<label
 								htmlFor='color format'


### PR DESCRIPTION
Summary:

Adds a "Design Tokens (JSON)" export emitting the DTCG shape { slug: { shade: { $type: "color", $value: "#hex" } } }, keyed by de-duped slug, always hex.
Generalizes color-format-selector hiding (Markdown + Tokens) and switches Prism language css/markdown/json by format.

Test plan:

npm run build passes.
Playwright: valid DTCG JSON, color-format hidden, duplicate-name de-dupe, copy yields parseable JSON.