### PR TITLE
feat: quick wins — copy-all, reorder, bulk-paste hex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,9 @@ the live page reflects the merged commit before calling anything fixed.
   `name`. The `name` is **auto-derived from the hue** (`colorUtils.nameFromHex`,
   e.g. blue) until the user edits it, after which it's left alone (tracked by
   `nameEdited` in `App`'s local state, *not* on the shared `ColorScale` type).
+  **Array order is the export/contrast order** — up/down buttons reorder it.
+  Scales can be bulk-created by pasting a hex list (`colorUtils.parseHexList`),
+  and each scale's ramp can be copied wholesale ("Copy all").
 - **Slug** — the export-safe form of a scale's `name`
   (`colorUtils.slugify`), de-duped across scales by `colorUtils.uniqueSlugs`
   (collisions get `-2`, `-3`…). Exported variables are `--<slug>-<shade>`

--- a/PLAN.md
+++ b/PLAN.md
@@ -65,29 +65,14 @@ color (a `500`), auto-named via `colorUtils.nameFromHex`.
 
 ## Feature roadmap
 
-Prioritized by leverage for the designer workflow and the designer→dev handoff.
-Tiers are rough guidance, not a strict order.
+Remaining quick wins (low effort, daily value). Earlier tiers (SCSS /
+cross-platform exports, swatch files, APCA, suggest-a-passing-shade) were
+dropped from scope.
 
-### Tier 2 — handoff bridges (export depth)
-
-- **SCSS** variables / map, and **cross-platform** formats (Android
-  `colors.xml`, iOS `UIColor` / SwiftUI `Color`).
-- **Swatch files** — `.ase` / `.aco` for direct import into design tools.
-
-### Tier 3 — accessibility (extend the differentiator)
-
-- **APCA contrast** alongside WCAG 2 (the WCAG 3 direction).
-- **Suggest a passing shade** — when a contrast pair fails, propose the nearest
-  shade in the ramp that passes.
-
-### Tier 4 — quick wins (low effort, daily value)
-
-- **Copy a whole scale** (array / all shades), not just one swatch.
-- **Reorder (drag) scales** and **duplicate a scale**.
+- **Duplicate a scale** — clone a scale (same color/name, new id) after it.
 - **Pin the input as a chosen shade** (e.g. "this hex is my 600") instead of
   always forcing it to 500; optional ramp-curve tuning.
 - **Curate which shades export** (systems rarely ship all 10).
-- **Bulk-create scales** by pasting a list of hex values.
 
 ---
 
@@ -119,3 +104,7 @@ Tiers are rough guidance, not a strict order.
   bottom bar (`CvdBar`) toggles a page-wide SVG `feColorMatrix` filter via a
   `body.cvd-*` class for protanopia / deuteranopia / tritanopia / achromatopsia;
   the filter covers `main` + `footer`, leaving the bar itself unfiltered.
+- **Quick wins** (branch `feature/quick-wins`). Per-scale "Copy all" (10 hexes,
+  newline-separated); reorder scales with up/down buttons (export + URL order
+  follows); bulk-paste hex (`colorUtils.parseHexList`) to create several
+  auto-named scales at once.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -111,6 +111,19 @@ const App = () => {
 		)
 	}, [])
 
+	const moveScale = useCallback((id: number, direction: -1 | 1) => {
+		setColorScales((prevScales) => {
+			const index = prevScales.findIndex((s) => s.id === id)
+			const target = index + direction
+			if (index < 0 || target < 0 || target >= prevScales.length) {
+				return prevScales
+			}
+			const next = [...prevScales]
+			;[next[index], next[target]] = [next[target], next[index]]
+			return next
+		})
+	}, [])
+
 	const handleNameChange = useCallback((id: number, newName: string) => {
 		setColorScales((prevScales) =>
 			prevScales.map((s) =>
@@ -130,6 +143,26 @@ const App = () => {
 		setLinkCopied(true)
 		setTimeout(() => setLinkCopied(false), 2000)
 	}, [])
+
+	const [bulkOpen, setBulkOpen] = useState(false)
+	const [bulkText, setBulkText] = useState('')
+	const addFromHexList = useCallback(() => {
+		const hexes = colorUtils.parseHexList(bulkText)
+		if (hexes.length === 0) return
+		setColorScales((prevScales) => {
+			let id = nextId
+			const added: ScaleState[] = hexes.map((color) => ({
+				id: id++,
+				color,
+				name: colorUtils.nameFromHex(color),
+				nameEdited: false,
+			}))
+			setNextId(id)
+			return [...prevScales, ...added]
+		})
+		setBulkText('')
+		setBulkOpen(false)
+	}, [bulkText, nextId])
 
 	return (
 		<>
@@ -162,7 +195,7 @@ const App = () => {
 				</div>
 			</div>
 			<section className='tracking-tight container p-s mb-xl bg-cream-50 rounded-lg border border-black-100 divide-y divide-gray-200'>
-				{colorScales.map((scale) => (
+				{colorScales.map((scale, index) => (
 					<div
 						key={scale.id}
 						className='py-4 flex flex-col sm:flex-row sm:items-start justify-between gap-s'
@@ -180,40 +213,105 @@ const App = () => {
 								}
 							/>
 							{colorScales.length > 1 && (
-								<button
-									onClick={() => removeColorScale(scale.id)}
-									className='px-s py-3xs border border-black-100 rounded-sm hover:bg-[#A51D1D] hover:text-[#FDF4F4] text-step--2 font-roboto-condensed flex items-center justify-center gap-3xs max-w-36'
-								>
-									<svg
-										xmlns='http://www.w3.org/2000/svg'
-										viewBox='0 0 448 512'
-										className='w-3 h-3 fill-current'
+								<div className='flex gap-3xs'>
+									<button
+										onClick={() => moveScale(scale.id, -1)}
+										disabled={index === 0}
+										aria-label='Move color up'
+										title='Move up'
+										className='px-2xs py-3xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 text-step--2 font-roboto-condensed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-current'
 									>
-										<path d='M135.2 17.7L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-7.2-14.3C304.4 6.8 292.3 0 279.2 0L168.8 0c-13.1 0-25.2 6.8-32.6 17.7zM32 128l384 0 0 320c0 35.3-28.7 64-64 64L96 512c-35.3 0-64-28.7-64-64L32 128zm96 64c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16z' />
-									</svg>
-									Remove
-								</button>
+										↑
+									</button>
+									<button
+										onClick={() => moveScale(scale.id, 1)}
+										disabled={
+											index === colorScales.length - 1
+										}
+										aria-label='Move color down'
+										title='Move down'
+										className='px-2xs py-3xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 text-step--2 font-roboto-condensed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-current'
+									>
+										↓
+									</button>
+									<button
+										onClick={() => removeColorScale(scale.id)}
+										aria-label='Remove color'
+										className='px-s py-3xs border border-black-100 rounded-sm hover:bg-[#A51D1D] hover:text-[#FDF4F4] text-step--2 font-roboto-condensed flex items-center justify-center gap-3xs'
+									>
+										<svg
+											xmlns='http://www.w3.org/2000/svg'
+											viewBox='0 0 448 512'
+											className='w-3 h-3 fill-current'
+										>
+											<path d='M135.2 17.7L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-7.2-14.3C304.4 6.8 292.3 0 279.2 0L168.8 0c-13.1 0-25.2 6.8-32.6 17.7zM32 128l384 0 0 320c0 35.3-28.7 64-64 64L96 512c-35.3 0-64-28.7-64-64L32 128zm96 64c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16l0 224c0 8.8 7.2 16 16 16s16-7.2 16-16l0-224c0-8.8-7.2-16-16-16z' />
+										</svg>
+										Remove
+									</button>
+								</div>
 							)}
 						</div>
 						<ColorScale2 baseColor={scale.color} />
 					</div>
 				))}
 
-				<button
-					onClick={addColorScale}
-					className='mt-s px-xs py-2xs bg-black-500 text-[#F4F5F9] rounded-sm hover:bg-yellow-500 hover:text-black-500 font-roboto-condensed flex items-center justify-center'
-				>
-					<span className='inline-block mr-2xs'>
-						<svg
-							xmlns='http://www.w3.org/2000/svg'
-							viewBox='0 0 448 512'
-							className='w-4 h-4 fill-current'
+				<div className='mt-s flex flex-wrap gap-xs'>
+					<button
+						onClick={addColorScale}
+						className='px-xs py-2xs bg-black-500 text-[#F4F5F9] rounded-sm hover:bg-yellow-500 hover:text-black-500 font-roboto-condensed flex items-center justify-center'
+					>
+						<span className='inline-block mr-2xs'>
+							<svg
+								xmlns='http://www.w3.org/2000/svg'
+								viewBox='0 0 448 512'
+								className='w-4 h-4 fill-current'
+							>
+								<path d='M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 144L48 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l144 0 0 144c0 17.7 14.3 32 32 32s32-14.3 32-32l0-144 144 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-144 0 0-144z' />
+							</svg>
+						</span>
+						Add a Color
+					</button>
+					<button
+						onClick={() => setBulkOpen((o) => !o)}
+						aria-expanded={bulkOpen}
+						className='px-xs py-2xs border border-black-100 rounded-sm hover:bg-black-500 hover:text-cream-100 font-roboto-condensed text-step--2'
+					>
+						{bulkOpen ? 'Cancel' : 'Paste a list'}
+					</button>
+				</div>
+
+				{bulkOpen && (
+					<div className='mt-s flex flex-col gap-2xs'>
+						<label
+							htmlFor='bulk-hex'
+							className='text-step--2 font-roboto-condensed'
 						>
-							<path d='M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 144L48 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l144 0 0 144c0 17.7 14.3 32 32 32s32-14.3 32-32l0-144 144 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-144 0 0-144z' />
-						</svg>
-					</span>
-					Add a Color
-				</button>
+							Paste hex values (commas, spaces, or new lines)
+						</label>
+						<textarea
+							id='bulk-hex'
+							rows={3}
+							value={bulkText}
+							onChange={(e) => setBulkText(e.target.value)}
+							placeholder='#5799DB, #E11D48, #16A34A'
+							className='w-full max-w-xl px-2xs py-3xs rounded-sm border border-black-100 text-step--2 font-mono'
+						/>
+						<button
+							onClick={addFromHexList}
+							disabled={
+								colorUtils.parseHexList(bulkText).length === 0
+							}
+							className='self-start px-xs py-2xs bg-black-500 text-[#F4F5F9] rounded-sm hover:bg-yellow-500 hover:text-black-500 font-roboto-condensed text-step--2 disabled:opacity-40'
+						>
+							Add{' '}
+							{colorUtils.parseHexList(bulkText).length || ''}{' '}
+							color
+							{colorUtils.parseHexList(bulkText).length === 1
+								? ''
+								: 's'}
+						</button>
+					</div>
+				)}
 			</section>
 
 			<h2 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -11,6 +11,7 @@ const ColorScale: React.FC<ColorScaleProps> = ({ baseColor }) => {
 	}, [baseColor])
 
 	const [copied, setCopied] = useState<string | null>(null)
+	const [allCopied, setAllCopied] = useState(false)
 
 	const copyHex = (hex: string) => {
 		navigator.clipboard.writeText(hex)
@@ -18,7 +19,14 @@ const ColorScale: React.FC<ColorScaleProps> = ({ baseColor }) => {
 		setTimeout(() => setCopied(null), 1200)
 	}
 
+	const copyAll = () => {
+		navigator.clipboard.writeText(shades.join('\n'))
+		setAllCopied(true)
+		setTimeout(() => setAllCopied(false), 1200)
+	}
+
 	return (
+		<div className='flex flex-col gap-2xs'>
 		<div className='flex flex-wrap gap-2xs'>
 			{shades.map((hexCode, index) => {
 				const isCopied = copied === hexCode
@@ -52,6 +60,18 @@ const ColorScale: React.FC<ColorScaleProps> = ({ baseColor }) => {
 					</button>
 				)
 			})}
+		</div>
+		<button
+			type='button'
+			onClick={copyAll}
+			className={`self-start px-xs py-3xs rounded-sm text-step--2 font-roboto-condensed border ${
+				allCopied
+					? 'border-green-600 bg-green-200 text-green-800'
+					: 'border-black-100 hover:bg-black-500 hover:text-cream-100'
+			}`}
+		>
+			{allCopied ? 'All copied!' : 'Copy all'}
+		</button>
 		</div>
 	)
 }

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -129,6 +129,16 @@ export const colorUtils = {
         })
     },
 
+    // Extracts every 6-digit hex color from free-form pasted text (commas,
+    // spaces, or newlines; '#' optional). Returns normalized #RRGGBB values
+    // in order. Used by the bulk-paste flow.
+    parseHexList(text: string): string[] {
+        const matches = text.match(/#?[0-9a-fA-F]{6}\b/g) ?? []
+        return matches.map(
+            (m) => `#${m.replace('#', '').toUpperCase()}`
+        )
+    },
+
     // --- Shareable palette serialization ---
     // A palette is encoded for the URL hash as `name:hex` pairs joined by
     // commas, e.g. `blue:5799DB,brand:E11D48`. Names are slugified and hexes


### PR DESCRIPTION
Summary:

- ColorScale: a 'Copy all' button copies the 10 shade hexes (newline-separated)
- App: reorder scales with up/down buttons (export + URL hash order follows; ends disabled appropriately)
- App: 'Paste a list' bulk-creates auto-named scales from pasted hex (colorUtils.parseHexList extracts valid #RRGGBB from free-form text)

Trim PLAN.md roadmap (drop SCSS/cross-platform, swatch files, APCA, suggest-a-passing-shade); record these in Done. Update CLAUDE.md.