### PR TITLE
feat: retain the type scale config in the URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,7 +373,11 @@ the live page reflects the merged commit before calling anything fixed.
   `toCss` (`:root` custom properties), `toTailwind` (`@theme` with
   `--text-step-N`, so steps become `text-step-N` utilities — the repo's own
   convention), and `toTokens` (DTCG `dimension` tokens under a `font-size`
-  group). No dark mode — a type scale isn't theme-dependent.
+  group). No dark mode — a type scale isn't theme-dependent. The config
+  serializes to the URL hash under `#t=` (`encodeConfig` / `decodeConfig`, the
+  eight numbers comma-joined) with the same mount-read + `replaceState`
+  live-sync + `hydrated` ref gate as the color tool's palette sharing; a
+  malformed hash falls back to the default.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The suite has two tools, linked by a top nav:
 - **Type Scales** (`/type`) — a fluid type-scale calculator. Set a font size and
   modular-scale ratio at a min and max viewport, preview every step live, and
   export `clamp()` steps as CSS custom properties, a Tailwind 4 `@theme` block,
-  or W3C Design Tokens JSON (Utopia-style output).
+  or W3C Design Tokens JSON (Utopia-style output). The config lives in the URL,
+  so a shared link reopens the exact scale.
 
 ## ✨ Features
 

--- a/src/components/TypeScale.tsx
+++ b/src/components/TypeScale.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useCallback } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
@@ -9,12 +9,16 @@ import {
 	toTailwind,
 	toTokens,
 	sizeAtViewport,
+	encodeConfig,
+	decodeConfig,
 	NAMED_RATIOS,
 	ratioName,
 	type TypeScaleConfig,
 } from '../utils/typeScale'
 
 type ExportFormat = 'css' | 'tailwind4' | 'tokens'
+
+const HASH_PREFIX = '#t='
 
 const DEFAULT_CONFIG: TypeScaleConfig = {
 	minViewport: 320,
@@ -25,6 +29,14 @@ const DEFAULT_CONFIG: TypeScaleConfig = {
 	maxRatio: 1.25,
 	stepsUp: 5,
 	stepsDown: 2,
+}
+
+// Reads a config from the URL hash, if present and valid. Client-only.
+const readHashConfig = (): TypeScaleConfig | null => {
+	if (typeof window === 'undefined') return null
+	const hash = window.location.hash
+	if (!hash.startsWith(HASH_PREFIX)) return null
+	return decodeConfig(decodeURIComponent(hash.slice(HASH_PREFIX.length)))
 }
 
 // A labeled number input wired to one config field. Empty/NaN keeps the last
@@ -123,6 +135,10 @@ const TypeScale = () => {
 		[]
 	)
 
+	// Gates the sync effect so it can't overwrite the hash before the initial
+	// read on mount (same pattern as the color tool).
+	const hydrated = useRef(false)
+
 	const steps = useMemo(() => generateTypeScale(config), [config])
 
 	const [format, setFormat] = useState<ExportFormat>('css')
@@ -142,6 +158,27 @@ const TypeScale = () => {
 	const [preview, setPreview] = useState(
 		Math.round((DEFAULT_CONFIG.minViewport + DEFAULT_CONFIG.maxViewport) / 2)
 	)
+
+	// On mount: a config in the URL wins; otherwise keep the default. Centers
+	// the preview on the loaded anchors.
+	useEffect(() => {
+		const fromHash = readHashConfig()
+		if (fromHash) {
+			setConfig(fromHash)
+			setPreview(
+				Math.round((fromHash.minViewport + fromHash.maxViewport) / 2)
+			)
+		}
+		hydrated.current = true
+	}, [])
+
+	// Live-sync the config to the URL hash (replaceState, so edits don't spam
+	// history). Runs only after the initial load.
+	useEffect(() => {
+		if (!hydrated.current) return
+		const url = `${window.location.pathname}${window.location.search}${HASH_PREFIX}${encodeConfig(config)}`
+		window.history.replaceState(null, '', url)
+	}, [config])
 
 	const [isClient, setIsClient] = useState(false)
 	useEffect(() => setIsClient(true), [])

--- a/src/utils/typeScale.ts
+++ b/src/utils/typeScale.ts
@@ -138,3 +138,54 @@ export const sizeAtViewport = (
 	const raw = step.minSize + (step.maxSize - step.minSize) * t
 	return Math.min(Math.max(raw, lo), hi)
 }
+
+// --- Shareable config serialization ---
+// The config encodes to a fixed, comma-separated list of its eight numbers,
+// for the URL hash (e.g. `320,1240,18,20,1.2,1.25,5,2`). Mirrors colorUtils'
+// encodePalette/decodePalette. Round-trips through encode/decode.
+
+const CONFIG_ORDER = [
+	'minViewport',
+	'maxViewport',
+	'minFontSize',
+	'maxFontSize',
+	'minRatio',
+	'maxRatio',
+	'stepsUp',
+	'stepsDown',
+] as const
+
+export const encodeConfig = (config: TypeScaleConfig): string =>
+	CONFIG_ORDER.map((k) => config[k]).join(',')
+
+// Parses the encoded string back into a config. Returns null if it doesn't
+// hold all eight finite numbers, so the caller can fall back to a default.
+// Viewports/sizes/steps are coerced sane (steps non-negative integers; ratios
+// kept >= 1) so a malformed hash can't produce a broken scale.
+export const decodeConfig = (encoded: string): TypeScaleConfig | null => {
+	if (!encoded) return null
+	const parts = encoded.split(',').map((p) => parseFloat(p.trim()))
+	if (parts.length !== CONFIG_ORDER.length || parts.some((n) => !Number.isFinite(n))) {
+		return null
+	}
+	const [
+		minViewport,
+		maxViewport,
+		minFontSize,
+		maxFontSize,
+		minRatio,
+		maxRatio,
+		stepsUp,
+		stepsDown,
+	] = parts
+	return {
+		minViewport,
+		maxViewport,
+		minFontSize,
+		maxFontSize,
+		minRatio: Math.max(1, minRatio),
+		maxRatio: Math.max(1, maxRatio),
+		stepsUp: Math.max(0, Math.round(stepsUp)),
+		stepsDown: Math.max(0, Math.round(stepsDown)),
+	}
+}


### PR DESCRIPTION
Summary:

- retain typescale config in the URL