### PR TITLE
feat: add a fluid Space & Grid calculator at /space

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ tools, each its own route, linked by a shared top nav ([SiteNav](./src/component
 - **Type Scales** (`/type`) — a fluid type-scale calculator: set min/max
   viewport, font size, and modular-scale ratio, preview every step, and copy a
   `:root` block of `clamp()` custom properties. See the **Type Scale** entry.
+- **Space & Grid** (`/space`) — a fluid spacing scale (T-shirt sizes 3xs–3xl on
+  an 8pt grid by default, plus one-up pairs) and a matching column grid, both
+  interpolating between min/max viewport via `clamp()`. See the **Space & Grid**
+  entry.
 
 The repo is still named "color-scale-generator"; the color tool is the primary
 surface and most of this file describes it.
@@ -61,7 +65,8 @@ command — the doc update is **part of that change, not a follow-up**.
   [astro.config.mjs](./astro.config.mjs).
 - **React 19** for interactivity, via `@astrojs/react`. Each tool is one React
   island mounted with `client:load` from its `.astro` route ([index.astro](./src/pages/index.astro)
-  → `App`; [type.astro](./src/pages/type.astro) → `TypeScale`).
+  → `App`; [type.astro](./src/pages/type.astro) → `TypeScale`;
+  [space.astro](./src/pages/space.astro) → `SpaceScale`).
 - **Tailwind CSS 4** via the `@tailwindcss/vite` plugin (no `tailwind.config`
   file — theme is defined in CSS with `@theme`, see
   [src/styles/global.css](./src/styles/global.css)).
@@ -82,10 +87,11 @@ src/
   pages/
     index.astro           Color tool route. SiteNav + <App> + SiteFooter in the layout.
     type.astro            Type Scale tool route. SiteNav + <TypeScale> + SiteFooter.
+    space.astro           Space & Grid tool route. SiteNav + <SpaceScale> + SiteFooter.
   layouts/Layout.astro    HTML shell: meta/OG tags (per-page title/description/path), PostHog, bg pattern, CVD SVG filters + CvdBar.
   components/
-    SiteNav.astro         Shared top nav (icon + label per tool: Color Scales | Type Scales); `active` marks the current tool.
-    SiteFooter.astro      Shared footer (the author credit link), used by both routes.
+    SiteNav.astro         Shared top nav (icon + label per tool: Color Scales | Type Scales | Space & Grid); `active` marks the current tool.
+    SiteFooter.astro      Shared footer (the author credit link), used by all routes.
     App.tsx               Color-tool island. Owns colorScales state; composes the three sections.
     ColorInput.tsx        Hex text field + native color picker for one scale. Validates #RRGGBB.
     ColorScale.tsx        Renders the 10 swatches (50–900) for one base color.
@@ -93,9 +99,11 @@ src/
     CodeBlock.tsx         Format/color-format selectors + Prism-highlighted, copyable export (CSS+Dark / Tailwind 4 / Markdown / Design Tokens).
     CvdBar.tsx            Fixed bottom bar; toggles a page-wide color-blindness SVG filter.
     TypeScale.tsx         Type-tool island. Owns the TypeScaleConfig; renders inputs, live preview, and the CSS export.
+    SpaceScale.tsx        Space & Grid island. Owns SpaceConfig + GridConfig; size table + pairs + grid + the CSS export.
   utils/
     colorUtils.ts         All color math + shared types, plus the SVG-export builders (scale/palette/pair → Figma-pasteable SVG). The one place color logic lives.
-    typeScale.ts          Fluid type-scale math: step sizes + clamp() builder + named ratios + CSS/Tailwind/Tokens emitters. The one place type-scale logic lives.
+    typeScale.ts          Fluid type-scale math: step sizes + clamp() builder + named ratios + CSS/Tailwind/Tokens emitters. Exports clampFor/pxToRem/round (shared with spaceScale).
+    spaceScale.ts         Fluid space + grid math: T-shirt sizes + one-up pairs + column/grid calc + CSS/Tailwind/Tokens emitters. Reuses typeScale's clampFor. The one place space/grid logic lives.
     clipboard.ts          copySvg: writes an SVG to the clipboard as text/plain + image/svg+xml (Figma paste). Shared by App + ContrastChecker.
   styles/
     global.css            Tailwind import + @theme tokens (colors, fonts, fluid type, spacing).
@@ -382,6 +390,24 @@ the live page reflects the merged commit before calling anything fixed.
   eight numbers comma-joined) with the same mount-read + `replaceState`
   live-sync + `hydrated` ref gate as the color tool's palette sharing; a
   malformed hash falls back to the default.
+- **Space & Grid** — the third tool ([SpaceScale](./src/components/SpaceScale.tsx)
+  at `/space`). Math lives in [spaceScale.ts](./src/utils/spaceScale.ts), which
+  **reuses `typeScale`'s `clampFor`/`pxToRem`/`round`** so all the fluid math is
+  in one place. **Sizes:** `SPACE_SIZES` is the T-shirt ladder (3xs–3xl) with
+  multipliers 0.25–6; `generateSpaceSizes` = `base × multiplier`, fluid between
+  the viewports. With the default `@min` base 16 the ramp is a clean 4/8pt grid
+  (4 8 12 16 24 32 48 64 96); `@max` base 20 makes it fluid. **Pairs:**
+  `generateSpacePairs` are one-up steps (3xs-2xs, …) that clamp from size N's
+  `@min` to size N+1's `@max`. **Grid:** `columnWidth = (container − (cols+1)
+  gutters) / cols` (one gutter of inline padding each side + between columns);
+  `computeGrid` returns the `@min`/`@max` container/gutter/column, with optional
+  `@min`-column rounding (up/down). `gutterClampFor` is the fluid gutter.
+  **Exports** match the type tool (`toCss` → `--space-*` + the grid `:root` plus
+  `.u-container`/`.u-grid`; `toTailwind` → `@theme` with `--spacing-*`;
+  `toTokens` → DTCG under `space`/`grid` groups). Preview swatches/bars use the
+  project blue `#5799DB` (not Utopia's pink). The config serializes to `#s=`
+  (`encodeSpaceGrid`/`decodeSpaceGrid`, ten numbers) with the same hash-sync
+  pattern. Output matches utopia.fyi for the same inputs.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,6 +77,14 @@ dropped from scope.
 
 ## Done
 
+- **Space & Grid calculator** (branch `feature/space-grid-calculator`). A third
+  tool at `/space`: fluid spacing scale (T-shirt sizes 3xs–3xl on an 8pt grid
+  by default + one-up pairs) and a matching column grid, in
+  `utils/spaceScale.ts` (reusing `typeScale`'s `clampFor`/`pxToRem`/`round`).
+  A `SpaceScale` island with own inputs (viewport 320–1440), a size table with
+  blue preview swatches, pair bars, a grid section (gutter/container/columns +
+  @min-column rounding), CSS/Tailwind/Tokens export, and `#s=` URL sync. Added
+  to the nav (ruler icon) and the smoke suite. Output matches utopia.fyi.
 - **Type Scale calculator** (branch `feature/type-scale-calculator`). A second
   tool at `/type`: fluid type-scale math in `utils/typeScale.ts`
   (`generateTypeScale` / `toCss` / named ratios), a `TypeScale` island with

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the **Designer Utils / MYOL Creative** suite.
 Live at **<https://tools.myol-creative.com/>**. No backend — a fully static
 Astro site; all math runs in the browser.
 
-The suite has two tools, linked by a top nav:
+The suite has three tools, linked by a top nav:
 
 - **Color Scales** (`/`) — everything below.
 - **Type Scales** (`/type`) — a fluid type-scale calculator. Set a font size and
@@ -19,6 +19,11 @@ The suite has two tools, linked by a top nav:
   export `clamp()` steps as CSS custom properties, a Tailwind 4 `@theme` block,
   or W3C Design Tokens JSON (Utopia-style output). The config lives in the URL,
   so a shared link reopens the exact scale.
+- **Space & Grid** (`/space`) — a fluid spacing scale (T-shirt sizes 3xs–3xl on
+  an 8pt grid by default, plus one-up pairs) and a matching column grid. Set the
+  base size and grid at a min and max viewport; export the `--space-*` ramp and
+  a `.u-container`/`.u-grid` layout as CSS, Tailwind 4, or Design Tokens. Config
+  lives in the URL too.
 
 ## ✨ Features
 

--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -2,15 +2,16 @@
 // Top nav shared across the tool pages. `active` marks the current tool so its
 // link reads as selected. Add new tools here as the suite grows.
 interface Props {
-	active: 'color' | 'type'
+	active: 'color' | 'type' | 'space'
 }
 const { active } = Astro.props
 
 // FontAwesome solid paths (viewBox 0 0 512 512): palette for the color tool,
-// a typography "T" for the type tool.
+// a typography "T" for the type tool, a combined ruler for space/grid.
 const icons: Record<Props['active'], string> = {
 	color: 'M204.3 5C104.9 24.4 24.8 104.3 5.2 203.4c-37 187 131.7 326.4 258.8 306.7 41.2-6.4 61.4-54.6 42.5-91.7-23.1-45.4 9.9-98.4 60.9-98.4l79.7 0c35.8 0 64.8-29.6 64.9-65.3C511.5 97.1 368.1-26.9 204.3 5zM96 320a32 32 0 1 1 0-64 32 32 0 1 1 0 64zm32-128a32 32 0 1 1 -64 0 32 32 0 1 1 64 0zm128-64a32 32 0 1 1 0-64 32 32 0 1 1 0 64zm128 64a32 32 0 1 1 -64 0 32 32 0 1 1 64 0z',
 	type: 'M254 52.8C249.3 40.3 237.3 32 224 32s-25.3 8.3-30 20.8L57.8 416 32 416c-17.7 0-32 14.3-32 32s14.3 32 32 32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-3.1 0 18-48 152.2 0 18 48-3.1 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-25.8 0L254 52.8zM279.8 304l-111.6 0L224 155.1 279.8 304z',
+	space: 'M.2 468.9C2.7 493.1 23.1 512 47.9 512l16.1 0 0-96c0-17.7 14.3-32 32-32s32 14.3 32 32l0 96 64 0 0-96c0-17.7 14.3-32 32-32s32 14.3 32 32l0 96 64 0 0-96c0-17.7 14.3-32 32-32s32 14.3 32 32l0 96 16.1 0c24.8 0 45.2-18.9 47.7-43.1 .2-1.6 .2-3.2 .2-4.9l0-320c0-26.5-21.5-48-48-48L48 96C21.5 96 0 117.5 0 144l0 320c0 1.6 .1 3.3 .2 4.9z',
 }
 
 const links: {
@@ -20,6 +21,7 @@ const links: {
 }[] = [
 	{ href: '/', label: 'Color Scales', key: 'color' },
 	{ href: '/type', label: 'Type Scales', key: 'type' },
+	{ href: '/space', label: 'Space & Grid', key: 'space' },
 ]
 ---
 

--- a/src/components/SpaceScale.tsx
+++ b/src/components/SpaceScale.tsx
@@ -1,0 +1,478 @@
+import { useMemo, useState, useEffect, useRef } from 'react'
+import Prism from 'prismjs'
+import 'prismjs/themes/prism-tomorrow.css'
+import 'prismjs/components/prism-css'
+import 'prismjs/components/prism-json'
+import {
+	generateSpaceSizes,
+	generateSpacePairs,
+	computeGrid,
+	gutterClampFor,
+	toCss,
+	toTailwind,
+	toTokens,
+	encodeSpaceGrid,
+	decodeSpaceGrid,
+	px,
+	type SpaceConfig,
+	type GridConfig,
+} from '../utils/spaceScale'
+
+type ExportFormat = 'css' | 'tailwind4' | 'tokens'
+
+const HASH_PREFIX = '#s='
+
+// 8pt-grid defaults: @min base 16 -> 4/8/12/16/24/32/48/64/96 (a clean 4/8pt
+// ramp); @max base 20 so the scale is genuinely fluid (20 -> 5/10/15/20/...).
+// Viewport 320–1440 per the project default.
+const DEFAULT_SPACE: SpaceConfig = {
+	minViewport: 320,
+	maxViewport: 1440,
+	minBase: 16,
+	maxBase: 20,
+}
+const DEFAULT_GRID: GridConfig = {
+	minViewport: 320,
+	maxViewport: 1440,
+	containerMax: 1240,
+	minGutter: 16,
+	maxGutter: 32,
+	columnMax: 60,
+	columns: 12,
+	roundMinColumn: 'none',
+}
+
+// The preview swatch/bar fill. The project's signature blue (same #5799DB the
+// color tool and the type tool's device screens use), not Utopia's pink.
+const SWATCH = '#5799DB'
+
+const readHash = (): { space: SpaceConfig; grid: GridConfig } | null => {
+	if (typeof window === 'undefined') return null
+	const hash = window.location.hash
+	if (!hash.startsWith(HASH_PREFIX)) return null
+	return decodeSpaceGrid(decodeURIComponent(hash.slice(HASH_PREFIX.length)))
+}
+
+const Field: React.FC<{
+	id: string
+	label: string
+	unit?: string
+	value: number
+	min?: number
+	step?: number
+	onChange: (v: number) => void
+}> = ({ id, label, unit, value, min, step, onChange }) => (
+	<div className='space-y-3xs'>
+		<label
+			htmlFor={id}
+			className='block text-step--2 font-roboto-condensed font-bold'
+		>
+			{label}
+		</label>
+		<div className='flex items-center gap-3xs rounded-sm border border-black-100 bg-cream-50 px-2xs focus-within:ring-2 focus-within:ring-blue-500'>
+			<input
+				id={id}
+				type='number'
+				inputMode='decimal'
+				min={min}
+				step={step}
+				value={value}
+				onChange={(e) => {
+					const v = parseFloat(e.target.value)
+					if (!Number.isNaN(v)) onChange(v)
+				}}
+				className='h-9 w-full bg-transparent text-step--1 tabular-nums focus:outline-hidden'
+			/>
+			{unit && <span className='text-step--2 text-black-300'>{unit}</span>}
+		</div>
+	</div>
+)
+
+const SpaceScale = () => {
+	const [space, setSpace] = useState<SpaceConfig>(DEFAULT_SPACE)
+	const [grid, setGrid] = useState<GridConfig>(DEFAULT_GRID)
+	const hydrated = useRef(false)
+
+	const setSpaceField = (key: keyof SpaceConfig, value: number) => {
+		setSpace((s) => {
+			const next = { ...s, [key]: value }
+			// Keep the grid's viewports in sync with the space viewports.
+			if (key === 'minViewport' || key === 'maxViewport') {
+				setGrid((g) => ({ ...g, [key]: value }))
+			}
+			return next
+		})
+	}
+	const setGridField = (key: keyof GridConfig, value: number) =>
+		setGrid((g) => ({ ...g, [key]: value }))
+
+	// On mount: a config in the URL wins; otherwise keep the default.
+	useEffect(() => {
+		const fromHash = readHash()
+		if (fromHash) {
+			setSpace(fromHash.space)
+			setGrid(fromHash.grid)
+		}
+		hydrated.current = true
+	}, [])
+
+	// Live-sync to the URL hash (replaceState, no history spam).
+	useEffect(() => {
+		if (!hydrated.current) return
+		const url = `${window.location.pathname}${window.location.search}${HASH_PREFIX}${encodeSpaceGrid(space, grid)}`
+		window.history.replaceState(null, '', url)
+	}, [space, grid])
+
+	const sizes = useMemo(() => generateSpaceSizes(space), [space])
+	const pairs = useMemo(() => generateSpacePairs(space), [space])
+	const gridResult = useMemo(() => computeGrid(grid), [grid])
+	const gutterClamp = useMemo(() => gutterClampFor(grid), [grid])
+
+	const [format, setFormat] = useState<ExportFormat>('css')
+	const code = useMemo(() => {
+		switch (format) {
+			case 'tailwind4':
+				return toTailwind(sizes, pairs, gridResult, gutterClamp)
+			case 'tokens':
+				return toTokens(sizes, pairs, gridResult, gutterClamp)
+			default:
+				return toCss(sizes, pairs, gridResult, gutterClamp)
+		}
+	}, [sizes, pairs, gridResult, gutterClamp, format])
+	const language = format === 'tokens' ? 'json' : 'css'
+
+	const [isClient, setIsClient] = useState(false)
+	useEffect(() => setIsClient(true), [])
+	useEffect(() => {
+		if (isClient) Prism.highlightAll()
+	}, [code, language, isClient])
+
+	const [copied, setCopied] = useState(false)
+	useEffect(() => setCopied(false), [code])
+	const copy = () => {
+		navigator.clipboard.writeText(code)
+		setCopied(true)
+		setTimeout(() => setCopied(false), 2000)
+	}
+
+	// Largest size's max, to scale the preview swatches proportionally.
+	const maxPreview = sizes[sizes.length - 1].maxSize
+
+	return (
+		<>
+			<h1 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
+				&#128208; Space &amp; Grid Calculator
+			</h1>
+			<p className='text-step--1 mb-s max-w-prose'>
+				A fluid spacing scale (T-shirt sizes on an 8pt grid by default)
+				and a matching layout grid, each interpolating between a min and
+				max viewport with a CSS{' '}
+				<code className='font-Ubuntu-mono-bold'>clamp()</code>.
+			</p>
+
+			{/* Space inputs */}
+			<section className='tracking-tight container p-xs mb-m bg-cream-50 rounded-lg border border-black-100'>
+				<div className='grid gap-s sm:grid-cols-2'>
+					<fieldset className='space-y-2xs'>
+						<legend className='text-step--2 font-roboto-condensed uppercase tracking-tight mb-3xs'>
+							Min viewport
+						</legend>
+						<div className='grid grid-cols-2 gap-2xs'>
+							<Field
+								id='space-min-vw'
+								label='Width'
+								unit='px'
+								min={0}
+								value={space.minViewport}
+								onChange={(v) => setSpaceField('minViewport', v)}
+							/>
+							<Field
+								id='space-min-base'
+								label='Base size'
+								unit='px'
+								min={1}
+								value={space.minBase}
+								onChange={(v) => setSpaceField('minBase', v)}
+							/>
+						</div>
+					</fieldset>
+					<fieldset className='space-y-2xs'>
+						<legend className='text-step--2 font-roboto-condensed uppercase tracking-tight mb-3xs'>
+							Max viewport
+						</legend>
+						<div className='grid grid-cols-2 gap-2xs'>
+							<Field
+								id='space-max-vw'
+								label='Width'
+								unit='px'
+								min={0}
+								value={space.maxViewport}
+								onChange={(v) => setSpaceField('maxViewport', v)}
+							/>
+							<Field
+								id='space-max-base'
+								label='Base size'
+								unit='px'
+								min={1}
+								value={space.maxBase}
+								onChange={(v) => setSpaceField('maxBase', v)}
+							/>
+						</div>
+					</fieldset>
+				</div>
+			</section>
+
+			{/* Size scale */}
+			<h2 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
+				&#128207; Space scale
+			</h2>
+			<section className='tracking-tight container p-xs mb-m bg-cream-50 rounded-lg border border-black-100'>
+				<div className='grid grid-cols-[auto_1fr_1fr] gap-x-s gap-y-2xs items-center'>
+					<span className='text-step--2 font-roboto-condensed uppercase tracking-tight text-black-300'>
+						Size
+					</span>
+					<span className='text-step--2 font-roboto-condensed uppercase tracking-tight text-black-300'>
+						@min
+					</span>
+					<span className='text-step--2 font-roboto-condensed uppercase tracking-tight text-black-300'>
+						@max
+					</span>
+					{sizes.map((s) => (
+						<SizeRow key={s.label} size={s} maxPreview={maxPreview} />
+					))}
+				</div>
+			</section>
+
+			{/* Pairs */}
+			<h2 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
+				&#11020; Space pairs
+			</h2>
+			<section className='tracking-tight container p-xs mb-m bg-cream-50 rounded-lg border border-black-100'>
+				<ul className='space-y-s'>
+					{pairs.map((p) => (
+						<li key={p.label} className='space-y-3xs'>
+							<div className='flex items-baseline justify-between text-step--2'>
+								<span className='font-roboto-condensed font-bold uppercase tracking-tight'>
+									{p.from} → {p.to}
+								</span>
+								<span className='text-black-300 tabular-nums'>
+									{px(p.minSize)} → {px(p.maxSize)}
+								</span>
+							</div>
+							{/* gradient bar: min block, taper, max block. End-block
+							    widths are capped so the bar can't overflow on narrow
+							    screens or with large bases. */}
+							<div className='flex items-center overflow-hidden'>
+								<span
+									className='h-6 rounded-xs shrink-0'
+									style={{
+										width: `${Math.min(p.minSize, 96)}px`,
+										backgroundColor: SWATCH,
+									}}
+								/>
+								<span
+									className='h-3 grow min-w-[12px]'
+									style={{
+										backgroundColor: `${SWATCH}66`,
+									}}
+								/>
+								<span
+									className='h-6 rounded-xs shrink-0'
+									style={{
+										width: `${Math.min(p.maxSize, 96)}px`,
+										backgroundColor: SWATCH,
+									}}
+								/>
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+
+			{/* Grid */}
+			<h2 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
+				&#128301; Layout grid
+			</h2>
+			<section className='tracking-tight container p-xs mb-m bg-cream-50 rounded-lg border border-black-100 space-y-s'>
+				<div className='grid gap-s sm:grid-cols-2 lg:grid-cols-4'>
+					<Field
+						id='grid-container'
+						label='Container max'
+						unit='px'
+						min={0}
+						value={grid.containerMax}
+						onChange={(v) => setGridField('containerMax', v)}
+					/>
+					<Field
+						id='grid-min-gutter'
+						label='Gutter @min'
+						unit='px'
+						min={0}
+						value={grid.minGutter}
+						onChange={(v) => setGridField('minGutter', v)}
+					/>
+					<Field
+						id='grid-max-gutter'
+						label='Gutter @max'
+						unit='px'
+						min={0}
+						value={grid.maxGutter}
+						onChange={(v) => setGridField('maxGutter', v)}
+					/>
+					<Field
+						id='grid-columns'
+						label='Columns'
+						min={1}
+						step={1}
+						value={grid.columns}
+						onChange={(v) =>
+							setGridField('columns', Math.max(1, Math.round(v)))
+						}
+					/>
+				</div>
+
+				<div className='grid grid-cols-[auto_1fr_1fr] gap-x-s gap-y-2xs text-step--1'>
+					<span className='font-roboto-condensed font-bold'>Width</span>
+					<span className='font-roboto-condensed font-bold'>@min</span>
+					<span className='font-roboto-condensed font-bold'>@max</span>
+
+					<span>Container</span>
+					<span className='tabular-nums'>{px(gridResult.minContainer)}</span>
+					<span className='tabular-nums'>{px(gridResult.maxContainer)}</span>
+
+					<span>Gutter</span>
+					<span className='tabular-nums'>{px(gridResult.minGutter)}</span>
+					<span className='tabular-nums'>{px(gridResult.maxGutter)}</span>
+
+					<span>Column</span>
+					<span className='tabular-nums'>
+						{px(gridResult.minColumn)}
+						{grid.roundMinColumn !== 'none' && (
+							<span className='text-black-300'>
+								{' '}
+								→ {px(gridResult.minColumnRounded)}
+							</span>
+						)}
+					</span>
+					<span className='tabular-nums'>{px(gridResult.maxColumn)}</span>
+				</div>
+
+				<div className='flex flex-wrap items-center gap-2xs text-step--2'>
+					<span className='text-black-300'>Round @min column:</span>
+					{(['none', 'down', 'up'] as const).map((r) => (
+						<button
+							key={r}
+							type='button'
+							onClick={() =>
+								setGrid((g) => ({ ...g, roundMinColumn: r }))
+							}
+							aria-pressed={grid.roundMinColumn === r}
+							className={`px-xs py-3xs rounded-sm border font-roboto-condensed ${
+								grid.roundMinColumn === r
+									? 'border-black-500 bg-black-500 text-cream-100'
+									: 'border-black-100 hover:bg-black-500 hover:text-cream-100'
+							}`}
+						>
+							{r === 'none' ? 'Off' : r}
+						</button>
+					))}
+				</div>
+			</section>
+
+			{/* Code export */}
+			<h3 className='text-step-1 sm:text-step-2 mb-2xs tracking-tight uppercase'>
+				&#128187; Code Snippet
+			</h3>
+			<div className='border border-black-100 bg-cream-50 rounded-lg overflow-hidden'>
+				<div className='p-xs'>
+					<div className='space-y-3xs'>
+						<label
+							htmlFor='space-format'
+							className='block text-step--2 font-roboto-condensed'
+						>
+							Format
+						</label>
+						<select
+							id='space-format'
+							value={format}
+							onChange={(e) =>
+								setFormat(e.target.value as ExportFormat)
+							}
+							className='px-xs py-2xs border border-black-100 rounded-sm bg-cream-50 text-step--2 focus:outline-hidden focus:ring-2 focus:ring-blue-500'
+						>
+							<option value='css'>CSS Variables</option>
+							<option value='tailwind4'>Tailwind 4.1</option>
+							<option value='tokens'>Design Tokens (JSON)</option>
+						</select>
+					</div>
+				</div>
+				<div className='relative bg-[#2d2d2d] text-cream-100'>
+					<button
+						onClick={copy}
+						className={`absolute top-6 right-6 z-10 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
+							copied
+								? 'bg-green-200 text-green-800'
+								: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
+						}`}
+					>
+						{copied ? 'Code Copied!' : 'Copy Code'}
+					</button>
+					<pre className='p-s max-h-128 overflow-auto'>
+						<code
+							className={`text-sm sm:text-lg ${
+								isClient ? `language-${language}` : ''
+							}`}
+						>
+							{code}
+						</code>
+					</pre>
+				</div>
+			</div>
+		</>
+	)
+}
+
+// One size row: label, multiplier-less, @min / @max each with a proportional
+// pink swatch (capped so the biggest size doesn't overflow the column).
+const SizeRow: React.FC<{
+	size: ReturnType<typeof generateSpaceSizes>[number]
+	maxPreview: number
+}> = ({ size, maxPreview }) => {
+	const cap = 120 // px ceiling for the largest swatch
+	const scale = (n: number) => Math.min(n, (n / maxPreview) * cap)
+	return (
+		<>
+			<span className='inline-flex items-center justify-center w-12 h-12 rounded-full bg-black-500 text-cream-100 text-step--2 font-bold uppercase'>
+				{size.label}
+			</span>
+			<div className='space-y-3xs'>
+				<span className='block text-step--2 text-black-400 tabular-nums'>
+					{px(size.minSize)}
+				</span>
+				<span
+					className='block rounded-xs'
+					style={{
+						width: `${scale(size.minSize)}px`,
+						height: `${scale(size.minSize)}px`,
+						backgroundColor: SWATCH,
+					}}
+				/>
+			</div>
+			<div className='space-y-3xs'>
+				<span className='block text-step--2 text-black-400 tabular-nums'>
+					{px(size.maxSize)}
+				</span>
+				<span
+					className='block rounded-xs'
+					style={{
+						width: `${scale(size.maxSize)}px`,
+						height: `${scale(size.maxSize)}px`,
+						backgroundColor: SWATCH,
+					}}
+				/>
+			</div>
+		</>
+	)
+}
+
+export default SpaceScale

--- a/src/pages/space.astro
+++ b/src/pages/space.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro'
+import SiteNav from '../components/SiteNav.astro'
+import SiteFooter from '../components/SiteFooter.astro'
+import SpaceScale from '../components/SpaceScale'
+---
+
+<Layout
+	title='Space & Grid Calculator | MYOL Creative'
+	description='Build a fluid spacing scale and layout grid with CSS clamp(). Set min and max viewport and base size, preview T-shirt sizes and pairs on an 8pt grid, configure a column grid, and copy the CSS.'
+	path='/space'
+>
+	<SiteNav active='space' />
+	<main class='mx-auto p-s bg-cream-100 rounded-md shadow-xs container'>
+		<SpaceScale client:load />
+	</main>
+	<SiteFooter />
+</Layout>

--- a/src/utils/spaceScale.ts
+++ b/src/utils/spaceScale.ts
@@ -1,0 +1,304 @@
+// Fluid space + grid math, mirroring Utopia's Space and Grid calculators.
+// Sizes are baseSize × multiplier, fluid between two viewports via clamp().
+// Reuses the type tool's clamp/rounding so all the fluid math lives in one
+// place (see typeScale.ts). The one place space/grid logic lives.
+
+import { clampFor, pxToRem, round } from './typeScale'
+
+export interface SpaceConfig {
+	minViewport: number // px
+	maxViewport: number // px
+	minBase: number // base space at the min viewport (px)
+	maxBase: number // base space at the max viewport (px)
+}
+
+// The T-shirt size ladder: label + multiplier applied to the base. With an 8pt
+// base (16) these land on a 4/8pt grid: 4 8 12 16 24 32 48 64 96.
+export const SPACE_SIZES: { label: string; multiplier: number }[] = [
+	{ label: '3xs', multiplier: 0.25 },
+	{ label: '2xs', multiplier: 0.5 },
+	{ label: 'xs', multiplier: 0.75 },
+	{ label: 's', multiplier: 1 },
+	{ label: 'm', multiplier: 1.5 },
+	{ label: 'l', multiplier: 2 },
+	{ label: 'xl', multiplier: 3 },
+	{ label: '2xl', multiplier: 4 },
+	{ label: '3xl', multiplier: 6 },
+]
+
+export interface SpaceSize {
+	label: string
+	minSize: number // px at minViewport
+	maxSize: number // px at maxViewport
+	clamp: string
+}
+
+export interface SpacePair {
+	label: string // e.g. `2xs-xs`
+	from: string
+	to: string
+	minSize: number // the smaller size's @min
+	maxSize: number // the larger size's @max
+	clamp: string
+}
+
+// Every size as { label, min px, max px, clamp() }.
+export const generateSpaceSizes = (config: SpaceConfig): SpaceSize[] => {
+	const { minViewport, maxViewport, minBase, maxBase } = config
+	return SPACE_SIZES.map(({ label, multiplier }) => {
+		const minSize = minBase * multiplier
+		const maxSize = maxBase * multiplier
+		return {
+			label,
+			minSize,
+			maxSize,
+			clamp: clampFor(minSize, maxSize, minViewport, maxViewport),
+		}
+	})
+}
+
+// One-up pairs (3xs-2xs, 2xs-xs, …): fluid from the smaller size's @min to the
+// larger size's @max, so spacing grows a notch as the viewport widens.
+export const generateSpacePairs = (config: SpaceConfig): SpacePair[] => {
+	const sizes = generateSpaceSizes(config)
+	const pairs: SpacePair[] = []
+	for (let i = 0; i < sizes.length - 1; i++) {
+		const a = sizes[i]
+		const b = sizes[i + 1]
+		pairs.push({
+			label: `${a.label}-${b.label}`,
+			from: a.label,
+			to: b.label,
+			minSize: a.minSize,
+			maxSize: b.maxSize,
+			clamp: clampFor(
+				a.minSize,
+				b.maxSize,
+				config.minViewport,
+				config.maxViewport
+			),
+		})
+	}
+	return pairs
+}
+
+// --- Grid ---
+
+export interface GridConfig {
+	minViewport: number
+	maxViewport: number
+	containerMax: number // max container width (px)
+	minGutter: number // gutter at the min viewport (px)
+	maxGutter: number // gutter at the max viewport (px)
+	columnMax: number // a column's max width (px)
+	columns: number
+	roundMinColumn: 'none' | 'up' | 'down'
+}
+
+// A column's width at a viewport: (container - (cols+1) gutters) / cols. The
+// container has one gutter of inline padding each side, plus gutters between
+// columns — so (columns + 1) gutters total. @min may be fractional, hence the
+// optional rounding (Utopia rounds the @min column up/down for whole pixels).
+export const columnWidth = (
+	container: number,
+	gutter: number,
+	columns: number
+): number => (container - (columns + 1) * gutter) / columns
+
+export interface GridResult {
+	minContainer: number
+	maxContainer: number
+	minGutter: number
+	maxGutter: number
+	minColumn: number
+	maxColumn: number
+	minColumnRounded: number // after roundMinColumn
+	columns: number
+}
+
+export const computeGrid = (config: GridConfig): GridResult => {
+	const {
+		minViewport,
+		containerMax,
+		minGutter,
+		maxGutter,
+		columns,
+		roundMinColumn,
+	} = config
+	// At @min the container is the min viewport; at @max it's the container max.
+	const minContainer = minViewport
+	const maxContainer = containerMax
+	const minColumn = columnWidth(minContainer, minGutter, columns)
+	const maxColumn = columnWidth(maxContainer, maxGutter, columns)
+	const minColumnRounded =
+		roundMinColumn === 'up'
+			? Math.ceil(minColumn)
+			: roundMinColumn === 'down'
+				? Math.floor(minColumn)
+				: minColumn
+	return {
+		minContainer,
+		maxContainer,
+		minGutter,
+		maxGutter,
+		minColumn,
+		maxColumn,
+		minColumnRounded,
+		columns,
+	}
+}
+
+// --- Exports (CSS / Tailwind 4 / Design Tokens), matching the type tool ---
+
+const spaceVarLines = (
+	sizes: SpaceSize[],
+	pairs: SpacePair[],
+	prefix: string
+): string => {
+	const sizeLines = sizes.map((s) => `  --${prefix}-${s.label}: ${s.clamp};`)
+	const pairLines = pairs.map((p) => `  --${prefix}-${p.label}: ${p.clamp};`)
+	return [
+		...sizeLines,
+		'',
+		'  /* One-up pairs */',
+		...pairLines,
+	].join('\n')
+}
+
+// :root custom properties for the space scale, plus the grid block.
+export const toCss = (
+	sizes: SpaceSize[],
+	pairs: SpacePair[],
+	grid: GridResult,
+	gutterClamp: string
+): string => {
+	const space = `:root {\n${spaceVarLines(sizes, pairs, 'space')}\n}`
+	const gridBlock =
+		`:root {\n` +
+		`  --grid-max-width: ${pxToRem(grid.maxContainer)};\n` +
+		`  --grid-gutter: ${gutterClamp};\n` +
+		`  --grid-columns: ${grid.columns};\n` +
+		`}\n\n` +
+		`.u-container {\n` +
+		`  max-width: var(--grid-max-width);\n` +
+		`  padding-inline: var(--grid-gutter);\n` +
+		`  margin-inline: auto;\n` +
+		`}\n\n` +
+		`.u-grid {\n` +
+		`  display: grid;\n` +
+		`  gap: var(--grid-gutter);\n` +
+		`}`
+	return `${space}\n\n${gridBlock}`
+}
+
+// Tailwind 4 @theme: --spacing-<label> so each becomes a spacing utility
+// (p-s, gap-m, …) and --container-* for the grid, matching the repo convention.
+export const toTailwind = (
+	sizes: SpaceSize[],
+	pairs: SpacePair[],
+	grid: GridResult,
+	gutterClamp: string
+): string => {
+	const lines = [
+		...sizes.map((s) => `  --spacing-${s.label}: ${s.clamp};`),
+		'',
+		'  /* One-up pairs */',
+		...pairs.map((p) => `  --spacing-${p.label}: ${p.clamp};`),
+		'',
+		'  /* Grid */',
+		`  --grid-max-width: ${pxToRem(grid.maxContainer)};`,
+		`  --grid-gutter: ${gutterClamp};`,
+		`  --grid-columns: ${grid.columns};`,
+	]
+	return `@theme {\n${lines.join('\n')}\n}`
+}
+
+// W3C Design Tokens (DTCG): dimension tokens for sizes + pairs under a
+// `space` group, and the grid values under a `grid` group.
+export const toTokens = (
+	sizes: SpaceSize[],
+	pairs: SpacePair[],
+	grid: GridResult,
+	gutterClamp: string
+): string => {
+	const space: Record<string, { $type: 'dimension'; $value: string }> = {}
+	for (const s of sizes) {
+		space[s.label] = { $type: 'dimension', $value: s.clamp }
+	}
+	for (const p of pairs) {
+		space[p.label] = { $type: 'dimension', $value: p.clamp }
+	}
+	const gridGroup = {
+		'max-width': {
+			$type: 'dimension' as const,
+			$value: pxToRem(grid.maxContainer),
+		},
+		gutter: { $type: 'dimension' as const, $value: gutterClamp },
+		columns: { $type: 'number' as const, $value: grid.columns },
+	}
+	return JSON.stringify({ space, grid: gridGroup }, null, 2)
+}
+
+// The gutter is itself a fluid value (min gutter -> max gutter), reused by the
+// grid CSS and the preview.
+export const gutterClampFor = (config: GridConfig): string =>
+	clampFor(
+		config.minGutter,
+		config.maxGutter,
+		config.minViewport,
+		config.maxViewport
+	)
+
+// px formatted for display, trimming trailing zeros (e.g. "7.17px", "60px").
+export const px = (n: number): string => `${round(n, 2)}px`
+
+// --- Shareable config serialization (space + grid) ---
+// The combined config encodes to a fixed comma-separated list for the URL hash.
+// Order is locked; decodeConfig drops malformed input so the caller falls back
+// to the default. Mirrors typeScale's encodeConfig/decodeConfig.
+
+const ROUND_CODES = { none: 0, up: 1, down: 2 } as const
+const ROUND_FROM_CODE: GridConfig['roundMinColumn'][] = ['none', 'up', 'down']
+
+export const encodeSpaceGrid = (
+	space: SpaceConfig,
+	grid: GridConfig
+): string =>
+	[
+		space.minViewport,
+		space.maxViewport,
+		space.minBase,
+		space.maxBase,
+		grid.containerMax,
+		grid.minGutter,
+		grid.maxGutter,
+		grid.columnMax,
+		grid.columns,
+		ROUND_CODES[grid.roundMinColumn],
+	].join(',')
+
+export const decodeSpaceGrid = (
+	encoded: string
+): { space: SpaceConfig; grid: GridConfig } | null => {
+	if (!encoded) return null
+	const p = encoded.split(',').map((x) => parseFloat(x.trim()))
+	if (p.length !== 10 || p.some((n) => !Number.isFinite(n))) return null
+	const [minV, maxV, minB, maxB, cMax, minG, maxG, colMax, cols, roundCode] = p
+	const space: SpaceConfig = {
+		minViewport: minV,
+		maxViewport: maxV,
+		minBase: minB,
+		maxBase: maxB,
+	}
+	const grid: GridConfig = {
+		minViewport: minV,
+		maxViewport: maxV,
+		containerMax: cMax,
+		minGutter: minG,
+		maxGutter: maxG,
+		columnMax: colMax,
+		columns: Math.max(1, Math.round(cols)),
+		roundMinColumn: ROUND_FROM_CODE[roundCode] ?? 'none',
+	}
+	return { space, grid }
+}

--- a/src/utils/typeScale.ts
+++ b/src/utils/typeScale.ts
@@ -25,12 +25,13 @@ export interface TypeStep {
 const REM = 16
 
 // Trim trailing zeros from a fixed-precision number (1.2500 -> 1.25, 1.0 -> 1).
-const round = (n: number, places = 4): string => {
+// Exported so the space/grid engine shares the same rounding + clamp math.
+export const round = (n: number, places = 4): string => {
 	const v = Number(n.toFixed(places))
 	return String(v)
 }
 
-const pxToRem = (px: number): string => `${round(px / REM)}rem`
+export const pxToRem = (px: number): string => `${round(px / REM)}rem`
 
 // Common modular-scale ratios, for a labeled picker. Value is the multiplier.
 export const NAMED_RATIOS: { value: number; label: string }[] = [
@@ -52,7 +53,8 @@ export const ratioName = (ratio: number): string =>
 // slope/intercept are the line through (minViewport, minSize) and
 // (maxViewport, maxSize); the preferred term is intercept + slope*100vw, fenced
 // by the min/max sizes. Guards a zero viewport span (returns a fixed size).
-const clampFor = (
+// Exported so the space/grid engine reuses the exact same fluid formula.
+export const clampFor = (
 	minSize: number,
 	maxSize: number,
 	minViewport: number,

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -24,12 +24,33 @@ test('type tool loads and outputs fluid CSS', async ({ page }) => {
 	)
 })
 
-test('nav moves between the two tools', async ({ page }) => {
+test('space tool loads and outputs a space scale + grid', async ({ page }) => {
+	await page.goto(`${BASE}/space`)
+	await expect(page).toHaveTitle(/Space & Grid Calculator/)
+	await expect(
+		page.getByRole('heading', { name: /Space & Grid Calculator/i })
+	).toBeVisible()
+	const code = page.locator('pre code')
+	// Default 8pt @min space scale (16 -> 20px fluid).
+	await expect(code).toContainText(
+		'--space-s: clamp(1rem, 0.9286rem + 0.3571vw, 1.25rem)'
+	)
+	// The grid block with the container utility.
+	await expect(code).toContainText('--grid-columns: 12;')
+	await expect(code).toContainText('.u-container {')
+})
+
+test('nav moves between the three tools', async ({ page }) => {
 	await page.goto(BASE)
 	await page.getByRole('link', { name: 'Type Scales' }).click()
 	await expect(page).toHaveURL(/\/type\/?$/)
 	await expect(
 		page.getByRole('heading', { name: /Type Scale Calculator/i })
+	).toBeVisible()
+	await page.getByRole('link', { name: 'Space & Grid' }).click()
+	await expect(page).toHaveURL(/\/space\/?$/)
+	await expect(
+		page.getByRole('heading', { name: /Space & Grid Calculator/i })
 	).toBeVisible()
 	await page.getByRole('link', { name: 'Color Scales' }).click()
 	await expect(


### PR DESCRIPTION
Summary:

A third tool in the suite. A fluid spacing scale (T-shirt sizes 3xs–3xl on an 8pt grid by default, plus one-up pairs) and a matching column grid, each interpolating between a min and max viewport with clamp(). Output matches utopia.fyi for the same inputs.

- utils/spaceScale.ts: the engine (sizes, pairs, grid column math, CSS/ Tailwind/Tokens emitters, URL serialization). Reuses typeScale's clampFor/pxToRem/round (now exported) so all fluid math lives in one place.
- SpaceScale.tsx: the island; own inputs (viewport 320–1440, 8pt base), a size table with preview swatches, pair bars, a grid section (gutter/container/ columns + @min-column rounding), the Prism export, and #s= URL sync.
- Swatches/bars use the project blue #5799DB and the design-system chip, not Utopia's pink/brown.
- SiteNav: add the Space & Grid tool (ruler icon). smoke.spec covers it + the 3-tool nav. Docs updated.