### PR TITLE
fix: emit DTCG 2025.10 color objects in the tokens export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ What the color tool does, top to bottom on one page:
    `prefers-color-scheme: dark` block with the ramp inverted), **Tailwind 4.1**
    `@theme` tokens (in **hex / HSL / RGB**), a **Markdown style guide** (a
    Hex + HSL table per color with WCAG text-on-white/black notes), or **W3C
-   Design Tokens (DTCG) JSON** (always hex), with one-click copy.
+   Design Tokens (DTCG 2025.10) JSON** (color objects, Figma-importable), with
+   one-click copy.
 4. **Share.** The palette lives in the URL hash (`#p=name:hex,…`), so editing
    updates the link live and a shared link reopens the exact palette. Also
    autosaved to `localStorage` (written, but not auto-restored — the URL or the
@@ -345,9 +346,14 @@ the live page reflects the merged commit before calling anything fixed.
   `tailwind4`, `markdown`, `tokens`; `cssDark` is the default); *color format* is
   the value encoding (`hex`, `hsl`, `rgb`). Independent selectors in `CodeBlock`,
   except the color format is hidden for the fixed-value formats (`markdown` →
-  Hex + HSL table; `tokens` → always hex). Those two build from raw-hex shade
-  data, not the `convertColor` pipeline the code formats use. `tokens` emits W3C
-  Design Tokens (DTCG), keyed by the de-duped slug. The Prism language switches
+  Hex + HSL table; `tokens` → a fixed DTCG color object). Those two build from
+  raw-hex shade data, not the `convertColor` pipeline the code formats use.
+  `tokens` emits W3C Design Tokens (**DTCG 2025.10**), keyed by the de-duped
+  slug: each `$value` is a color *object*
+  (`colorUtils.hexToDtcgColor` → `{ colorSpace: 'srgb', components, alpha, hex }`,
+  components normalized 0..1 at 6 decimals), which is what Figma's native
+  variables importer expects — a bare hex string is the old style and no longer
+  imports. The Prism language switches
   `css` / `markdown` / `json` by format (`cssDark`, `tailwind4` use `css`).
 - **Dark mode in exports** — the dark ramp is the light ramp **mirrored**
   (`colorUtils.mirrorHexes` — 50↔900, 100↔800, …), so light tints become dark

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ Export in four formats, with one-click copy:
 -   **Tailwind 4** — `@theme` tokens, plus a `.dark` override.
 -   **Markdown style guide** — a Hex + HSL table per color with WCAG
     text-on-white/black notes and a Dark column.
--   **Design Tokens (DTCG) JSON** — W3C Design Tokens with top-level `light` and
-    `dark` groups, for Style Dictionary / Tokens Studio / Figma.
+-   **Design Tokens (DTCG 2025.10) JSON** — W3C Design Tokens with top-level
+    `light` and `dark` groups, for Style Dictionary / Tokens Studio / Figma.
+    Colors use the 2025.10 color-object `$value`
+    (`colorSpace` / `components` / `alpha` / `hex`), which is what Figma's
+    native variables importer expects.
 
 Code formats (CSS / Tailwind) also let you pick the value encoding: **HEX**,
 **HSL**, or **RGB**.

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -205,13 +205,16 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 			}
 
 			case 'tokens': {
-				// W3C Design Tokens (DTCG): top-level `light` and `dark` groups,
-				// each keyed by slug -> shade -> { $type, $value }. Dark uses the
-				// mirrored ramp. Always hex.
-				type Group = Record<
-					string,
-					Record<string, { $type: 'color'; $value: string }>
-				>
+				// W3C Design Tokens (DTCG 2025.10): top-level `light` and `dark`
+				// groups, each keyed by slug -> shade -> { $type, $value }, where
+				// $value is a color object (colorSpace/components/alpha/hex) —
+				// the format Figma's native variables importer expects. Dark uses
+				// the mirrored ramp.
+				type ColorToken = {
+					$type: 'color'
+					$value: ReturnType<typeof colorUtils.hexToDtcgColor>
+				}
+				type Group = Record<string, Record<string, ColorToken>>
 				const light: Group = {}
 				const dark: Group = {}
 				colorData.forEach(({ slug, shades }) => {
@@ -221,10 +224,13 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 						shades.map((s) => s.hex)
 					)
 					shades.forEach(({ shade, hex }, i) => {
-						light[slug][shade] = { $type: 'color', $value: hex }
+						light[slug][shade] = {
+							$type: 'color',
+							$value: colorUtils.hexToDtcgColor(hex),
+						}
 						dark[slug][shade] = {
 							$type: 'color',
-							$value: mirrored[i],
+							$value: colorUtils.hexToDtcgColor(mirrored[i]),
 						}
 					})
 				})

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -582,6 +582,28 @@ export const colorUtils = {
             .replace(/"/g, '&quot;')
     },
 
+    // A hex as a DTCG 2025.10 color object. The spec (and Figma's native
+    // variables importer) requires `$value` to be an object — a bare hex string
+    // is the pre-2025.10 style and no longer imports. `components` are the sRGB
+    // channels normalized to 0..1, rounded to 6 decimals with trailing zeros
+    // dropped; `hex` stays as the human-readable fallback.
+    hexToDtcgColor(hex: string): {
+        colorSpace: 'srgb'
+        components: number[]
+        alpha: number
+        hex: string
+    } {
+        const components = colorUtils
+            .hexToRgb(hex)
+            .map((channel) => Number((channel / 255).toFixed(6)))
+        return {
+            colorSpace: 'srgb',
+            components,
+            alpha: 1,
+            hex: hex.toUpperCase(),
+        }
+    },
+
     // The dark-mode ramp: the same shade slots in reverse, so a light tint
     // (e.g. 50) takes the value of its opposite end (900) and vice versa,
     // keeping hue and chroma. shadeHexes is the ordered 50..900 list.

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -12,6 +12,24 @@ test('color tool loads and generates a scale', async ({ page }) => {
 	await expect(page.locator('.hex-code')).toHaveCount(10)
 })
 
+test('design tokens export uses the DTCG 2025.10 color object', async ({
+	page,
+}) => {
+	await page.goto(BASE)
+	// "Format" (not "Color Format", which is a separate selector).
+	await page.getByLabel('Format', { exact: true }).selectOption('tokens')
+	const code = page.locator('pre code')
+	// $value must be a color object, not a bare hex string — Figma's native
+	// variables importer rejects the pre-2025.10 style.
+	await expect(code).toContainText('"$type": "color"')
+	await expect(code).toContainText('"colorSpace": "srgb"')
+	await expect(code).toContainText('"components": [')
+	await expect(code).toContainText('"alpha": 1')
+	await expect(code).toContainText('"hex": "#')
+	// The old shape (a hex directly as $value) must be gone.
+	await expect(code).not.toContainText(/"\$value": "#/)
+})
+
 test('type tool loads and outputs fluid CSS', async ({ page }) => {
 	await page.goto(`${BASE}/type`)
 	await expect(page).toHaveTitle(/Type Scale Calculator/)


### PR DESCRIPTION
Summary:

The tokens export used the pre-2025.10 style where a color's $value is a bare hex string, which Figma's native variables importer no longer accepts. Each $value is now a color object:

  { "colorSpace": "srgb", "components": [...], "alpha": 1, "hex": "#FFF2EE" }

- colorUtils.hexToDtcgColor builds it (sRGB channels normalized to 0..1 at 6 decimals, trailing zeros dropped; hex kept as the readable fallback), so the conversion stays in the color engine.
- CodeBlock's tokens case uses it for both the light and mirrored dark ramps.
- smoke.spec asserts the new shape and that a bare-hex $value is gone.

Closes #45