### PR TITLE
feat: download the code snippet as a txt file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ What the color tool does, top to bottom on one page:
    `@theme` tokens (in **hex / HSL / RGB**), a **Markdown style guide** (a
    Hex + HSL table per color with WCAG text-on-white/black notes), or **W3C
    Design Tokens (DTCG 2025.10) JSON** (color objects, Figma-importable), with
-   one-click copy.
+   one-click copy or download as a `.txt` file.
 4. **Share.** The palette lives in the URL hash (`#p=name:hex,…`), so editing
    updates the link live and a shared link reopens the exact palette. Also
    autosaved to `localStorage` (written, but not auto-restored — the URL or the
@@ -106,6 +106,7 @@ src/
     typeScale.ts          Fluid type-scale math: step sizes + clamp() builder + named ratios + CSS/Tailwind/Tokens emitters. Exports clampFor/pxToRem/round (shared with spaceScale).
     spaceScale.ts         Fluid space + grid math: T-shirt sizes + one-up pairs + column/grid calc + CSS/Tailwind/Tokens emitters. Reuses typeScale's clampFor. The one place space/grid logic lives.
     clipboard.ts          copySvg: writes an SVG to the clipboard as text/plain + image/svg+xml (Figma paste). Shared by App + ContrastChecker.
+    download.ts           downloadText: saves a code snippet as a file via a Blob URL. Shared by all three export blocks.
   styles/
     global.css            Tailwind import + @theme tokens (colors, fonts, fluid type, spacing).
     reset.css             CSS reset (imported into the base layer).
@@ -355,6 +356,14 @@ the live page reflects the merged commit before calling anything fixed.
   variables importer expects — a bare hex string is the old style and no longer
   imports. The Prism language switches
   `css` / `markdown` / `json` by format (`cssDark`, `tailwind4` use `css`).
+- **Snippet download** — every export block (color, type, space) pairs **Copy
+  Code** with **Download .txt**, which saves the exact snippet on screen via
+  `download.ts`'s `downloadText` (a Blob URL + synthetic `<a download>`; no
+  backend). Filenames are `<tool>-<format>.txt` (e.g. `color-scales-tokens.txt`,
+  `type-scale-css.txt`), so downloading several formats doesn't collide. The
+  `.txt` extension is deliberate per issue #46 — note Figma's *native* variables
+  importer and most token plugins filter their file picker to `.json`, so a
+  `.txt` token export may need renaming before import.
 - **Dark mode in exports** — the dark ramp is the light ramp **mirrored**
   (`colorUtils.mirrorHexes` — 50↔900, 100↔800, …), so light tints become dark
   and vice versa, keeping hue/chroma. Where each format puts it: `cssDark` →

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The suite has three tools, linked by a top nav:
 
 ### 📋 Code export
 
-Export in four formats, with one-click copy:
+Export in four formats — copy with one click, or download the snippet as a
+`.txt` file:
 
 -   **CSS + Dark Mode** — `:root` variables plus a `prefers-color-scheme: dark`
     block with the ramp mirrored.
@@ -70,7 +71,8 @@ Export in four formats, with one-click copy:
     native variables importer expects.
 
 Code formats (CSS / Tailwind) also let you pick the value encoding: **HEX**,
-**HSL**, or **RGB**.
+**HSL**, or **RGB**. The Type and Space tools have the same copy/download pair
+on their export blocks.
 
 ### 🔗 Share & persist
 

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { colorUtils, type ColorScale } from '../utils/colorUtils'
+import { downloadText } from '../utils/download'
 import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
@@ -264,6 +265,10 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 		}, 2000)
 	}
 
+	const download = () => {
+		downloadText(`color-scales-${themeFormat}.txt`, formattedCode)
+	}
+
 	return (
 		<div className='border border-black-100 bg-cream-50 rounded-lg overflow-hidden'>
 			<div className='p-xs space-y-s'>
@@ -315,16 +320,24 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ colorScales }) => {
 				</div>
 			</div>
 			<div className='relative bg-[#2d2d2d] text-cream-100'>
-				<button
-					onClick={copyToClipboard}
-					className={`absolute top-6 right-6 z-10 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
-						isCopied
-							? 'bg-green-200 text-green-800'
-							: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
-					}`}
-				>
-					{isCopied ? 'Code Copied!' : 'Copy Code'}
-				</button>
+				<div className='absolute top-6 right-6 z-10 flex flex-wrap justify-end gap-2xs'>
+					<button
+						onClick={copyToClipboard}
+						className={`px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
+							isCopied
+								? 'bg-green-200 text-green-800'
+								: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
+						}`}
+					>
+						{isCopied ? 'Code Copied!' : 'Copy Code'}
+					</button>
+					<button
+						onClick={download}
+						className='px-xs py-2xs rounded-sm font-roboto-condensed font-bold bg-cream-200 text-black-400 hover:bg-yellow-500'
+					>
+						Download .txt
+					</button>
+				</div>
 				<pre className='p-s max-h-128 overflow-auto'>
 					<code
 						className={`text-sm sm:text-lg ${

--- a/src/components/SpaceScale.tsx
+++ b/src/components/SpaceScale.tsx
@@ -3,6 +3,7 @@ import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-json'
+import { downloadText } from '../utils/download'
 import {
 	generateSpaceSizes,
 	generateSpacePairs,
@@ -154,6 +155,7 @@ const SpaceScale = () => {
 		setCopied(true)
 		setTimeout(() => setCopied(false), 2000)
 	}
+	const download = () => downloadText(`space-grid-${format}.txt`, code)
 
 	// Largest size's max, to scale the preview swatches proportionally.
 	const maxPreview = sizes[sizes.length - 1].maxSize
@@ -407,16 +409,24 @@ const SpaceScale = () => {
 					</div>
 				</div>
 				<div className='relative bg-[#2d2d2d] text-cream-100'>
-					<button
-						onClick={copy}
-						className={`absolute top-6 right-6 z-10 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
-							copied
-								? 'bg-green-200 text-green-800'
-								: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
-						}`}
-					>
-						{copied ? 'Code Copied!' : 'Copy Code'}
-					</button>
+					<div className='absolute top-6 right-6 z-10 flex flex-wrap justify-end gap-2xs'>
+						<button
+							onClick={copy}
+							className={`px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
+								copied
+									? 'bg-green-200 text-green-800'
+									: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
+							}`}
+						>
+							{copied ? 'Code Copied!' : 'Copy Code'}
+						</button>
+						<button
+							onClick={download}
+							className='px-xs py-2xs rounded-sm font-roboto-condensed font-bold bg-cream-200 text-black-400 hover:bg-yellow-500'
+						>
+							Download .txt
+						</button>
+					</div>
 					<pre className='p-s max-h-128 overflow-auto'>
 						<code
 							className={`text-sm sm:text-lg ${

--- a/src/components/TypeScale.tsx
+++ b/src/components/TypeScale.tsx
@@ -3,6 +3,7 @@ import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-json'
+import { downloadText } from '../utils/download'
 import {
 	generateTypeScale,
 	toCss,
@@ -233,6 +234,7 @@ const TypeScale = () => {
 		setCopied(true)
 		setTimeout(() => setCopied(false), 2000)
 	}
+	const download = () => downloadText(`type-scale-${format}.txt`, code)
 
 	return (
 		<>
@@ -485,16 +487,24 @@ const TypeScale = () => {
 					</div>
 				</div>
 				<div className='relative bg-[#2d2d2d] text-cream-100'>
-					<button
-						onClick={copy}
-						className={`absolute top-6 right-6 z-10 px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
-							copied
-								? 'bg-green-200 text-green-800'
-								: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
-						}`}
-					>
-						{copied ? 'Code Copied!' : 'Copy Code'}
-					</button>
+					<div className='absolute top-6 right-6 z-10 flex flex-wrap justify-end gap-2xs'>
+						<button
+							onClick={copy}
+							className={`px-xs py-2xs rounded-sm font-roboto-condensed font-bold ${
+								copied
+									? 'bg-green-200 text-green-800'
+									: 'bg-cream-200 text-black-400 hover:bg-yellow-500'
+							}`}
+						>
+							{copied ? 'Code Copied!' : 'Copy Code'}
+						</button>
+						<button
+							onClick={download}
+							className='px-xs py-2xs rounded-sm font-roboto-condensed font-bold bg-cream-200 text-black-400 hover:bg-yellow-500'
+						>
+							Download .txt
+						</button>
+					</div>
 					<pre className='p-s max-h-128 overflow-auto'>
 						<code
 							className={`text-sm sm:text-lg ${

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,13 @@
+// Client-side file download for the export blocks. There's no backend, so the
+// snippet is turned into a Blob URL and handed to a synthetic <a download>.
+
+export const downloadText = (filename: string, contents: string): void => {
+	const url = URL.createObjectURL(new Blob([contents], { type: 'text/plain' }))
+	const link = document.createElement('a')
+	link.href = url
+	link.download = filename
+	document.body.appendChild(link)
+	link.click()
+	link.remove()
+	URL.revokeObjectURL(url)
+}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -58,6 +58,21 @@ test('space tool loads and outputs a space scale + grid', async ({ page }) => {
 	await expect(code).toContainText('.u-container {')
 })
 
+test('code snippet downloads as a txt file', async ({ page }) => {
+	await page.goto(BASE)
+	await page.getByLabel('Format', { exact: true }).selectOption('tokens')
+	const [download] = await Promise.all([
+		page.waitForEvent('download'),
+		page.getByRole('button', { name: 'Download .txt' }).click(),
+	])
+	expect(download.suggestedFilename()).toBe('color-scales-tokens.txt')
+	const stream = await download.createReadStream()
+	const chunks: Buffer[] = []
+	for await (const chunk of stream) chunks.push(chunk as Buffer)
+	// The downloaded file is the same snippet shown in the code block.
+	expect(Buffer.concat(chunks).toString()).toContain('"colorSpace": "srgb"')
+})
+
 test('nav moves between the three tools', async ({ page }) => {
 	await page.goto(BASE)
 	await page.getByRole('link', { name: 'Type Scales' }).click()


### PR DESCRIPTION
Summary:

Every export block (color, type, space) now pairs Copy Code with a Download .txt button that saves the snippet on screen. Filenames are tool-format.txt so downloading several formats doesn't collide.

Closes #46