### PR TITLE
fix: emit DTCG 2025.10 dimension objects in the type and space tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,17 @@ the live page reflects the merged commit before calling anything fixed.
   variables importer expects — a bare hex string is the old style and no longer
   imports. The Prism language switches
   `css` / `markdown` / `json` by format (`cssDark`, `tailwind4` use `css`).
+- **Fluid values as tokens** — DTCG 2025.10 requires a `dimension` `$value` to
+  be an **object**, `{ value: <number>, unit: 'px' | 'rem' }` — never a string.
+  A `clamp()` therefore has no representation as a dimension token (one number,
+  one unit), and Figma variables have no viewport concept to bind it to either.
+  So the Type and Space tools' `toTokens` flatten each fluid value to its two
+  viewport anchors under top-level **`min`** and **`max`** groups, which import
+  as Figma modes — deliberately mirroring the color tool's `light`/`dark`
+  groups. `typeScale.remDimension(px)` (+ the `DimensionToken` type) builds the
+  object and is shared by both engines; `grid.columns` stays `$type: 'number'`,
+  which is already spec-valid. The `clamp()` strings live only in the CSS and
+  Tailwind formats, which is where they're actually consumable.
 - **Snippet download** — every export block (color, type, space) pairs **Copy
   Code** with **Download .txt**, which saves the exact snippet on screen via
   `download.ts`'s `downloadText` (a Blob URL + synthetic `<a download>`; no
@@ -399,8 +410,8 @@ the live page reflects the merged commit before calling anything fixed.
   export formats (a Format selector, Prism-highlighted like the color tool):
   `toCss` (`:root` custom properties), `toTailwind` (`@theme` with
   `--text-step-N`, so steps become `text-step-N` utilities — the repo's own
-  convention), and `toTokens` (DTCG `dimension` tokens under a `font-size`
-  group). No dark mode — a type scale isn't theme-dependent. The config
+  convention), and `toTokens` (DTCG dimension tokens under a `font-size` group
+  — see **Fluid values as tokens**). No dark mode — a type scale isn't theme-dependent. The config
   serializes to the URL hash under `#t=` (`encodeConfig` / `decodeConfig`, the
   eight numbers comma-joined) with the same mount-read + `replaceState`
   live-sync + `hydrated` ref gate as the color tool's palette sharing; a
@@ -419,7 +430,8 @@ the live page reflects the merged commit before calling anything fixed.
   `@min`-column rounding (up/down). `gutterClampFor` is the fluid gutter.
   **Exports** match the type tool (`toCss` → `--space-*` + the grid `:root` plus
   `.u-container`/`.u-grid`; `toTailwind` → `@theme` with `--spacing-*`;
-  `toTokens` → DTCG under `space`/`grid` groups). Preview swatches/bars use the
+  `toTokens` → DTCG under `space`/`grid` groups, see **Fluid values as
+  tokens**). Preview swatches/bars use the
   project blue `#5799DB` (not Utopia's pink). The config serializes to `#s=`
   (`encodeSpaceGrid`/`decodeSpaceGrid`, ten numbers) with the same hash-sync
   pattern. Output matches utopia.fyi for the same inputs.

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,6 +77,13 @@ dropped from scope.
 
 ## Done
 
+- **DTCG 2025.10 compliance across all three tools** (branches
+  `fix/dtcg-color-object` #45, `feature/download-code-snippet` #46). Color
+  `$value`s became color objects (`colorUtils.hexToDtcgColor`). Type and Space
+  dimension `$value`s became `{ value, unit }` objects
+  (`typeScale.remDimension`); since a `clamp()` can't be a DTCG dimension, both
+  flatten to `min`/`max` anchor groups that import as Figma modes. Every export
+  block also gained a **Download .txt** button (`utils/download.ts`).
 - **Space & Grid calculator** (branch `feature/space-grid-calculator`). A third
   tool at `/space`: fluid spacing scale (T-shirt sizes 3xs–3xl on an 8pt grid
   by default + one-up pairs) and a matching column grid, in
@@ -108,7 +115,7 @@ dropped from scope.
   over default on load; malformed hashes fall back to the default.
 - **Design Tokens (DTCG) JSON export** (branch `feature/design-tokens-export`).
   New `tokens` format in `CodeBlock` emitting W3C Design Tokens
-  (`{ slug: { shade: { $type, $value } } }`, always hex) for Style Dictionary /
+  (`{ slug: { shade: { $type, $value } } }`) for Style Dictionary /
   Tokens Studio / Figma; JSON syntax-highlighted; color-format selector hidden.
 - **OKLCH shade generation** (branch `feature/oklch-ramp`). Ramps built in OKLCH
   (perceptual): base anchors 500, lightness interpolates to fixed light/dark

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ The suite has three tools, linked by a top nav:
 - **Type Scales** (`/type`) — a fluid type-scale calculator. Set a font size and
   modular-scale ratio at a min and max viewport, preview every step live, and
   export `clamp()` steps as CSS custom properties, a Tailwind 4 `@theme` block,
-  or W3C Design Tokens JSON (Utopia-style output). The config lives in the URL,
+  or W3C Design Tokens JSON (`min`/`max` groups, Figma-importable as modes —
+  a `clamp()` can't be a DTCG dimension). The config lives in the URL,
   so a shared link reopens the exact scale.
 - **Space & Grid** (`/space`) — a fluid spacing scale (T-shirt sizes 3xs–3xl on
   an 8pt grid by default, plus one-up pairs) and a matching column grid. Set the
   base size and grid at a min and max viewport; export the `--space-*` ramp and
-  a `.u-container`/`.u-grid` layout as CSS, Tailwind 4, or Design Tokens. Config
-  lives in the URL too.
+  a `.u-container`/`.u-grid` layout as CSS, Tailwind 4, or Design Tokens (same
+  `min`/`max` groups as the Type tool). Config lives in the URL too.
 
 ## ✨ Features
 

--- a/src/components/SpaceScale.tsx
+++ b/src/components/SpaceScale.tsx
@@ -135,7 +135,7 @@ const SpaceScale = () => {
 			case 'tailwind4':
 				return toTailwind(sizes, pairs, gridResult, gutterClamp)
 			case 'tokens':
-				return toTokens(sizes, pairs, gridResult, gutterClamp)
+				return toTokens(sizes, pairs, gridResult)
 			default:
 				return toCss(sizes, pairs, gridResult, gutterClamp)
 		}

--- a/src/utils/spaceScale.ts
+++ b/src/utils/spaceScale.ts
@@ -3,7 +3,13 @@
 // Reuses the type tool's clamp/rounding so all the fluid math lives in one
 // place (see typeScale.ts). The one place space/grid logic lives.
 
-import { clampFor, pxToRem, round } from './typeScale'
+import {
+	clampFor,
+	pxToRem,
+	remDimension,
+	round,
+	type DimensionToken,
+} from './typeScale'
 
 export interface SpaceConfig {
 	minViewport: number // px
@@ -213,30 +219,40 @@ export const toTailwind = (
 	return `@theme {\n${lines.join('\n')}\n}`
 }
 
-// W3C Design Tokens (DTCG): dimension tokens for sizes + pairs under a
-// `space` group, and the grid values under a `grid` group.
+// W3C Design Tokens (DTCG 2025.10). A dimension token holds a single number +
+// unit, so the fluid clamp()s flatten to their two anchors as `min` and `max`
+// groups — see typeScale's toTokens for the reasoning. Each group carries the
+// space scale and the grid values at that viewport.
 export const toTokens = (
 	sizes: SpaceSize[],
 	pairs: SpacePair[],
-	grid: GridResult,
-	gutterClamp: string
+	grid: GridResult
 ): string => {
-	const space: Record<string, { $type: 'dimension'; $value: string }> = {}
-	for (const s of sizes) {
-		space[s.label] = { $type: 'dimension', $value: s.clamp }
+	const spaceGroup = (anchor: 'minSize' | 'maxSize') => {
+		const space: Record<string, DimensionToken> = {}
+		for (const s of sizes) space[s.label] = remDimension(s[anchor])
+		for (const p of pairs) space[p.label] = remDimension(p[anchor])
+		return space
 	}
-	for (const p of pairs) {
-		space[p.label] = { $type: 'dimension', $value: p.clamp }
-	}
-	const gridGroup = {
-		'max-width': {
-			$type: 'dimension' as const,
-			$value: pxToRem(grid.maxContainer),
-		},
-		gutter: { $type: 'dimension' as const, $value: gutterClamp },
+	const gridGroup = (container: number, gutter: number) => ({
+		'max-width': remDimension(container),
+		gutter: remDimension(gutter),
 		columns: { $type: 'number' as const, $value: grid.columns },
-	}
-	return JSON.stringify({ space, grid: gridGroup }, null, 2)
+	})
+	return JSON.stringify(
+		{
+			min: {
+				space: spaceGroup('minSize'),
+				grid: gridGroup(grid.minContainer, grid.minGutter),
+			},
+			max: {
+				space: spaceGroup('maxSize'),
+				grid: gridGroup(grid.maxContainer, grid.maxGutter),
+			},
+		},
+		null,
+		2
+	)
 }
 
 // The gutter is itself a fluid value (min gutter -> max gutter), reused by the

--- a/src/utils/typeScale.ts
+++ b/src/utils/typeScale.ts
@@ -33,6 +33,19 @@ export const round = (n: number, places = 4): string => {
 
 export const pxToRem = (px: number): string => `${round(px / REM)}rem`
 
+// A DTCG 2025.10 dimension token. The spec requires $value to be an object of
+// one number + one unit — never a string — which is why a clamp() can't be a
+// dimension token at all (see toTokens). Shared with the space/grid engine.
+export interface DimensionToken {
+	$type: 'dimension'
+	$value: { value: number; unit: 'rem' }
+}
+
+export const remDimension = (px: number): DimensionToken => ({
+	$type: 'dimension',
+	$value: { value: Number((px / REM).toFixed(4)), unit: 'rem' },
+})
+
 // Common modular-scale ratios, for a labeled picker. Value is the multiplier.
 export const NAMED_RATIOS: { value: number; label: string }[] = [
 	{ value: 1.067, label: 'Minor Second' },
@@ -115,14 +128,23 @@ export const toTailwind = (steps: TypeStep[]): string => {
 	return `@theme {\n${lines.join('\n')}\n}`
 }
 
-// W3C Design Tokens (DTCG): one dimension token per step, value = the clamp().
-// Keyed `step-N` (negatives as `step--1`) under a `font-size` group.
+// W3C Design Tokens (DTCG 2025.10). A dimension token holds a single number +
+// unit, so a fluid clamp() has no representation — and Figma variables have no
+// viewport concept either. The scale therefore flattens to its two anchors as
+// `min` and `max` groups, which import as Figma modes (mirroring the color
+// tool's light/dark groups). Steps are keyed `step-N` (negatives as `step--1`).
 export const toTokens = (steps: TypeStep[]): string => {
-	const sizes: Record<string, { $type: 'dimension'; $value: string }> = {}
+	const min: Record<string, DimensionToken> = {}
+	const max: Record<string, DimensionToken> = {}
 	for (const s of steps) {
-		sizes[`step-${s.step}`] = { $type: 'dimension', $value: s.clamp }
+		min[`step-${s.step}`] = remDimension(s.minSize)
+		max[`step-${s.step}`] = remDimension(s.maxSize)
 	}
-	return JSON.stringify({ 'font-size': sizes }, null, 2)
+	return JSON.stringify(
+		{ min: { 'font-size': min }, max: { 'font-size': max } },
+		null,
+		2
+	)
 }
 
 // The px size at an arbitrary viewport width, for the live preview. Linearly

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,6 +1,15 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 
 const BASE = 'http://localhost:4321'
+
+// Pick a Format ("Format", not "Color Format", which is a separate selector).
+// The export block only reacts once the island has hydrated — Prism adds the
+// `language-*` class at that point — so selecting any earlier fires a change
+// event that nothing is listening to yet and the format silently stays put.
+const selectFormat = async (page: Page, value: string): Promise<void> => {
+	await expect(page.locator('pre code')).toHaveClass(/language-/)
+	await page.getByLabel('Format', { exact: true }).selectOption(value)
+}
 
 test('color tool loads and generates a scale', async ({ page }) => {
 	await page.goto(BASE)
@@ -16,8 +25,7 @@ test('design tokens export uses the DTCG 2025.10 color object', async ({
 	page,
 }) => {
 	await page.goto(BASE)
-	// "Format" (not "Color Format", which is a separate selector).
-	await page.getByLabel('Format', { exact: true }).selectOption('tokens')
+	await selectFormat(page, 'tokens')
 	const code = page.locator('pre code')
 	// $value must be a color object, not a bare hex string — Figma's native
 	// variables importer rejects the pre-2025.10 style.
@@ -28,6 +36,27 @@ test('design tokens export uses the DTCG 2025.10 color object', async ({
 	await expect(code).toContainText('"hex": "#')
 	// The old shape (a hex directly as $value) must be gone.
 	await expect(code).not.toContainText(/"\$value": "#/)
+})
+
+test('type and space tokens use DTCG 2025.10 dimension objects', async ({
+	page,
+}) => {
+	for (const [path, sample] of [
+		['/type', '"step-0"'],
+		['/space', '"s"'],
+	]) {
+		await page.goto(`${BASE}${path}`)
+		await selectFormat(page, 'tokens')
+		const code = page.locator('pre code')
+		// Fluid values flatten to min/max anchor groups — a clamp() can't be a
+		// DTCG dimension, and Figma variables have no viewport concept.
+		await expect(code).toContainText('"min": {')
+		await expect(code).toContainText('"max": {')
+		await expect(code).toContainText(sample)
+		// $value must be a { value, unit } object, never a string.
+		await expect(code).toContainText('"unit": "rem"')
+		await expect(code).not.toContainText(/"\$value": "/)
+	}
 })
 
 test('type tool loads and outputs fluid CSS', async ({ page }) => {
@@ -60,7 +89,7 @@ test('space tool loads and outputs a space scale + grid', async ({ page }) => {
 
 test('code snippet downloads as a txt file', async ({ page }) => {
 	await page.goto(BASE)
-	await page.getByLabel('Format', { exact: true }).selectOption('tokens')
+	await selectFormat(page, 'tokens')
 	const [download] = await Promise.all([
 		page.waitForEvent('download'),
 		page.getByRole('button', { name: 'Download .txt' }).click(),


### PR DESCRIPTION
Summary:

The spec requires a dimension $value to be an object of one number and one unit, never a string. Both tools emitted clamp() strings, which are invalid and — since Figma variables have no viewport concept — unimportable.

A clamp() has no dimension-token representation at all, so each fluid value now flattens to its two viewport anchors under top-level min and max groups, which import as Figma modes. This mirrors the color tool's light/dark groups. The clamp() strings remain in the CSS and Tailwind exports, where they're actually consumable.

Also guards the format-selector tests against a hydration race: selecting before the island hydrates fires a change event nothing is listening to yet.